### PR TITLE
feat: optimasi sinkronisasi data sektor & sub-sektor via pasardana endpoints

### DIFF
--- a/internal/models/sector_new.go
+++ b/internal/models/sector_new.go
@@ -1,17 +1,46 @@
 package models
 
 type SectorNew struct {
-	Id   int
-	Name string
+	Id          int
+	Code        *string
+	Name        string
+	NameEn      *string
+	Description *string
 }
 
 type SubSector struct {
-	Id       int
-	Name     string
-	SectorId int
+	Id          int
+	SectorId    int
+	Code        *string
+	Name        string
+	NameEn      *string
+	Description *string
+}
+
+type PasardanaNewSector struct {
+	Id          int     `json:"Id"`
+	Code        *string `json:"Code"`
+	Name        string  `json:"Name"`
+	NameEn      *string `json:"NameEn"`
+	Description *string `json:"Description"`
+}
+
+type PasardanaNewSubSector struct {
+	Id            int     `json:"Id"`
+	FkNewSectorId int     `json:"fkNewSectorId"`
+	Code          *string `json:"Code"`
+	Name          string  `json:"Name"`
+	NameEn        *string `json:"NameEn"`
+	Description   *string `json:"Description"`
+}
+
+type BasicResponseWithCode struct {
+	Id   int     `json:"id"`
+	Code *string `json:"code,omitempty"`
+	Name string  `json:"name"`
 }
 
 type SectorSyncNewResponse struct {
-	Sectors    []BasicResponse `json:"sectors"`
-	SubSectors []BasicResponse `json:"sub_sectors"`
+	Sectors    []BasicResponseWithCode `json:"sectors"`
+	SubSectors []BasicResponseWithCode `json:"sub_sectors"`
 }

--- a/internal/repositories/sector_search_repository.go
+++ b/internal/repositories/sector_search_repository.go
@@ -11,8 +11,8 @@ import (
 )
 
 type SectorSearchRepository interface {
-	UpsertNewSectors(ctx context.Context, sectors []models.SectorNew) ([]models.BasicResponse, error)
-	UpsertNewSubSectors(ctx context.Context, subSectors []models.SubSector) ([]models.BasicResponse, error)
+	UpsertNewSectors(ctx context.Context, sectors []models.SectorNew) ([]models.BasicResponseWithCode, error)
+	UpsertNewSubSectors(ctx context.Context, subSectors []models.SubSector) ([]models.BasicResponseWithCode, error)
 }
 
 type sectorSearchRepository struct {
@@ -25,9 +25,9 @@ func NewSectorSearchRepository(pool *pgxpool.Pool) SectorSearchRepository {
 	}
 }
 
-func (r *sectorSearchRepository) UpsertNewSectors(ctx context.Context, sectors []models.SectorNew) ([]models.BasicResponse, error) {
+func (r *sectorSearchRepository) UpsertNewSectors(ctx context.Context, sectors []models.SectorNew) ([]models.BasicResponseWithCode, error) {
 	if len(sectors) == 0 {
-		return make([]models.BasicResponse, 0), nil
+		return make([]models.BasicResponseWithCode, 0), nil
 	}
 
 	tx, err := r.pool.Begin(ctx)
@@ -37,27 +37,33 @@ func (r *sectorSearchRepository) UpsertNewSectors(ctx context.Context, sectors [
 	defer tx.Rollback(ctx)
 
 	query := `
-		INSERT INTO idxstock.sector (id, name, last_modified)
-		VALUES ($1, $2, now())
+		INSERT INTO idxstock.sector (id, code, name, name_en, description, last_modified)
+		VALUES ($1, $2, $3, $4, $5, now())
 		ON CONFLICT (id) DO UPDATE SET
+			code = EXCLUDED.code,
 			name = EXCLUDED.name,
+			name_en = EXCLUDED.name_en,
+			description = EXCLUDED.description,
 			last_modified = now()
-		WHERE (idxstock.sector.name IS DISTINCT FROM EXCLUDED.name)
-		RETURNING id, name
+		WHERE (idxstock.sector.name IS DISTINCT FROM EXCLUDED.name OR
+		       idxstock.sector.code IS DISTINCT FROM EXCLUDED.code OR
+		       idxstock.sector.description IS DISTINCT FROM EXCLUDED.description OR
+		       idxstock.sector.name_en IS DISTINCT FROM EXCLUDED.name_en)
+		RETURNING id, code, name
 	`
 
 	batch := &pgx.Batch{}
 	for _, s := range sectors {
-		batch.Queue(query, s.Id, s.Name)
+		batch.Queue(query, s.Id, s.Code, s.Name, s.NameEn, s.Description)
 	}
 
 	br := tx.SendBatch(ctx, batch)
 	defer br.Close()
 
-	updated := make([]models.BasicResponse, 0)
+	updated := make([]models.BasicResponseWithCode, 0)
 	for i := 0; i < len(sectors); i++ {
-		var res models.BasicResponse
-		err := br.QueryRow().Scan(&res.Id, &res.Name)
+		var res models.BasicResponseWithCode
+		err := br.QueryRow().Scan(&res.Id, &res.Code, &res.Name)
 		if err != nil {
 			continue
 		}
@@ -76,9 +82,9 @@ func (r *sectorSearchRepository) UpsertNewSectors(ctx context.Context, sectors [
 	return updated, nil
 }
 
-func (r *sectorSearchRepository) UpsertNewSubSectors(ctx context.Context, subSectors []models.SubSector) ([]models.BasicResponse, error) {
+func (r *sectorSearchRepository) UpsertNewSubSectors(ctx context.Context, subSectors []models.SubSector) ([]models.BasicResponseWithCode, error) {
 	if len(subSectors) == 0 {
-		return make([]models.BasicResponse, 0), nil
+		return make([]models.BasicResponseWithCode, 0), nil
 	}
 
 	tx, err := r.pool.Begin(ctx)
@@ -88,29 +94,35 @@ func (r *sectorSearchRepository) UpsertNewSubSectors(ctx context.Context, subSec
 	defer tx.Rollback(ctx)
 
 	query := `
-		INSERT INTO idxstock.sub_sector (id, name, sector_id, last_modified)
-		VALUES ($1, $2, $3, now())
+		INSERT INTO idxstock.sub_sector (id, code, name, name_en, description, sector_id, last_modified)
+		VALUES ($1, $2, $3, $4, $5, $6, now())
 		ON CONFLICT (id) DO UPDATE SET
+			code = EXCLUDED.code,
 			name = EXCLUDED.name,
+			name_en = EXCLUDED.name_en,
+			description = EXCLUDED.description,
 			sector_id = EXCLUDED.sector_id,
 			last_modified = now()
 		WHERE (idxstock.sub_sector.name IS DISTINCT FROM EXCLUDED.name OR
+		       idxstock.sub_sector.code IS DISTINCT FROM EXCLUDED.code OR
+		       idxstock.sub_sector.description IS DISTINCT FROM EXCLUDED.description OR
+		       idxstock.sub_sector.name_en IS DISTINCT FROM EXCLUDED.name_en OR
 		       idxstock.sub_sector.sector_id IS DISTINCT FROM EXCLUDED.sector_id)
-		RETURNING id, name
+		RETURNING id, code, name
 	`
 
 	batch := &pgx.Batch{}
 	for _, sub := range subSectors {
-		batch.Queue(query, sub.Id, sub.Name, sub.SectorId)
+		batch.Queue(query, sub.Id, sub.Code, sub.Name, sub.NameEn, sub.Description, sub.SectorId)
 	}
 
 	br := tx.SendBatch(ctx, batch)
 	defer br.Close()
 
-	updated := make([]models.BasicResponse, 0)
+	updated := make([]models.BasicResponseWithCode, 0)
 	for i := 0; i < len(subSectors); i++ {
-		var res models.BasicResponse
-		err := br.QueryRow().Scan(&res.Id, &res.Name)
+		var res models.BasicResponseWithCode
+		err := br.QueryRow().Scan(&res.Id, &res.Code, &res.Name)
 		if err != nil {
 			continue
 		}

--- a/internal/services/pasardana_service.go
+++ b/internal/services/pasardana_service.go
@@ -12,6 +12,8 @@ type PasardanaService interface {
 	FetchStockIDs() ([]models.PasardanaStock, error)
 	FetchSectors() ([]models.PasardanaSector, error)
 	FetchStockSearchResult() ([]models.PasardanaSearchResult, error)
+	FetchNewSectors() ([]models.PasardanaNewSector, error)
+	FetchNewSubSectors() ([]models.PasardanaNewSubSector, error)
 }
 
 type pasardanaService struct{}
@@ -41,6 +43,24 @@ func (s *pasardanaService) FetchSectors() ([]models.PasardanaSector, error) {
 func (s *pasardanaService) FetchStockSearchResult() ([]models.PasardanaSearchResult, error) {
 	url := "https://www.pasardana.id/api/StockSearchResult/GetAll"
 	var results []models.PasardanaSearchResult
+	if err := s.fetch(url, &results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (s *pasardanaService) FetchNewSectors() ([]models.PasardanaNewSector, error) {
+	url := "https://www.pasardana.id/api/StockNewSector/GetAll"
+	var results []models.PasardanaNewSector
+	if err := s.fetch(url, &results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (s *pasardanaService) FetchNewSubSectors() ([]models.PasardanaNewSubSector, error) {
+	url := "https://www.pasardana.id/api/StockNewSubSector/GetAll"
+	var results []models.PasardanaNewSubSector
 	if err := s.fetch(url, &results); err != nil {
 		return nil, err
 	}

--- a/internal/usecases/sector_usecase.go
+++ b/internal/usecases/sector_usecase.go
@@ -41,45 +41,44 @@ func (u *sectorUsecase) SyncSectors(ctx context.Context) ([]models.SectorRespons
 }
 
 func (u *sectorUsecase) SyncNewSectors(ctx context.Context) (*models.SectorSyncNewResponse, error) {
-	results, err := u.pasardanaService.FetchStockSearchResult()
+	// Sync Sectors
+	pasardanaSectors, err := u.pasardanaService.FetchNewSectors()
 	if err != nil {
 		return nil, err
 	}
 
-	// Deduplicate sectors and sub-sectors
-	sectorMap := make(map[int]models.SectorNew)
-	subSectorMap := make(map[int]models.SubSector)
-
-	for _, res := range results {
-		if res.NewSectorId > 0 {
-			sectorMap[res.NewSectorId] = models.SectorNew{
-				Id:   res.NewSectorId,
-				Name: res.NewSectorName,
-			}
-		}
-		if res.NewSubSectorId > 0 {
-			subSectorMap[res.NewSubSectorId] = models.SubSector{
-				Id:       res.NewSubSectorId,
-				Name:     res.NewSubSectorName,
-				SectorId: res.NewSectorId,
-			}
-		}
+	sectors := make([]models.SectorNew, 0, len(pasardanaSectors))
+	for _, ps := range pasardanaSectors {
+		sectors = append(sectors, models.SectorNew{
+			Id:          ps.Id,
+			Code:        ps.Code,
+			Name:        ps.Name,
+			NameEn:      ps.NameEn,
+			Description: ps.Description,
+		})
 	}
 
-	sectors := make([]models.SectorNew, 0, len(sectorMap))
-	for _, s := range sectorMap {
-		sectors = append(sectors, s)
-	}
-
-	subSectors := make([]models.SubSector, 0, len(subSectorMap))
-	for _, sub := range subSectorMap {
-		subSectors = append(subSectors, sub)
-	}
-
-	// Upsert sectors first due to FK constraint
 	updatedSectors, err := u.searchRepo.UpsertNewSectors(ctx, sectors)
 	if err != nil {
 		return nil, err
+	}
+
+	// Sync SubSectors
+	pasardanaSubSectors, err := u.pasardanaService.FetchNewSubSectors()
+	if err != nil {
+		return nil, err
+	}
+
+	subSectors := make([]models.SubSector, 0, len(pasardanaSubSectors))
+	for _, ps := range pasardanaSubSectors {
+		subSectors = append(subSectors, models.SubSector{
+			Id:          ps.Id,
+			SectorId:    ps.FkNewSectorId,
+			Code:        ps.Code,
+			Name:        ps.Name,
+			NameEn:      ps.NameEn,
+			Description: ps.Description,
+		})
 	}
 
 	updatedSubSectors, err := u.searchRepo.UpsertNewSubSectors(ctx, subSectors)

--- a/migrations/004_create_sector_subsector_tables.sql
+++ b/migrations/004_create_sector_subsector_tables.sql
@@ -1,14 +1,20 @@
 CREATE TABLE IF NOT EXISTS idxstock.sector
 (
     id             INT            PRIMARY KEY,
+    code           VARCHAR(50),
     name           VARCHAR(200)   NOT NULL,
+    name_en        VARCHAR(200),
+    description    TEXT,
     last_modified  TIMESTAMPTZ    NOT NULL DEFAULT now()
 );
 
 CREATE TABLE IF NOT EXISTS idxstock.sub_sector
 (
     id             INT            PRIMARY KEY,
+    code           VARCHAR(50),
     name           VARCHAR(200)   NOT NULL,
+    name_en        VARCHAR(200),
+    description    TEXT,
     sector_id      INT            NOT NULL REFERENCES idxstock.sector(id),
     last_modified  TIMESTAMPTZ    NOT NULL DEFAULT now()
 );


### PR DESCRIPTION
Implementasi optimasi endpoint `/api/v1/sector/sync` untuk sync sektor dan sub-sektor langsung dari masing-masing endpoint referensi Pasardana agar menyertakan data yang lebih komprehensif, tidak buat file sql baru (menggunakan alter/modifikasi existing schema sql), dan menambahkan `WHERE IS DISTINCT FROM` logic ke repo search. Resolves #14.