### PR TITLE
feat: multi-source daily stock history synchronization

### DIFF
--- a/internal/handlers/history_handler.go
+++ b/internal/handlers/history_handler.go
@@ -18,7 +18,14 @@ func NewHistoryHandler(usecase usecases.HistoryUsecase) *HistoryHandler {
 }
 
 func (h *HistoryHandler) SyncStockHistoryHandler(c fiber.Ctx) error {
-	source := c.Query("source", "pasardana")
+	source := c.Query("source")
+
+	if source == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Source is required",
+		})
+	}
+
 	var req models.SyncHistoryRequest
 
 	if err := c.Bind().JSON(&req); err != nil {

--- a/internal/handlers/history_handler.go
+++ b/internal/handlers/history_handler.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"github.com/KAnggara75/IDXStocks/internal/models"
+	"github.com/KAnggara75/IDXStocks/internal/usecases"
+	"github.com/gofiber/fiber/v3"
+	"github.com/sirupsen/logrus"
+)
+
+type HistoryHandler struct {
+	usecase usecases.HistoryUsecase
+}
+
+func NewHistoryHandler(usecase usecases.HistoryUsecase) *HistoryHandler {
+	return &HistoryHandler{
+		usecase: usecase,
+	}
+}
+
+func (h *HistoryHandler) SyncStockHistoryHandler(c fiber.Ctx) error {
+	source := c.Query("source", "pasardana")
+	var req models.SyncHistoryRequest
+
+	if err := c.Bind().JSON(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid request body",
+		})
+	}
+
+	if req.Year == 0 || req.Month == 0 || req.Day == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Year, month, and day are required",
+		})
+	}
+
+	err := h.usecase.SyncStockHistory(c.Context(), req, source)
+	if err != nil {
+		logrus.Errorf("Failed to sync stock history for %02d/%02d/%04d from %s: %v", req.Month, req.Day, req.Year, source, err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"message": "Stock history synchronization completed successfully",
+		"date":    req,
+		"source":  source,
+	})
+}

--- a/internal/models/history.go
+++ b/internal/models/history.go
@@ -1,0 +1,85 @@
+package models
+
+import "time"
+
+type StockHistory struct {
+	Code                string    `json:"code"`
+	Date                time.Time `json:"date"`
+	Previous            *float64  `json:"previous"`
+	OpenPrice           *float64  `json:"open_price"`
+	FirstTrade          *float64  `json:"first_trade"`
+	High                *float64  `json:"high"`
+	Low                 *float64  `json:"low"`
+	Close               *float64  `json:"close"`
+	Change              *float64  `json:"change"`
+	Volume              *float64  `json:"volume"`
+	Value               *float64  `json:"value"`
+	Frequency           *float64  `json:"frequency"`
+	IndexIndividual     *float64  `json:"index_individual"`
+	Offer               *float64  `json:"offer"`
+	OfferVolume         *float64  `json:"offer_volume"`
+	Bid                 *float64  `json:"bid"`
+	BidVolume           *float64  `json:"bid_volume"`
+	ListedShares        *float64  `json:"listed_shares"`
+	TradebleShares      *float64  `json:"tradeble_shares"`
+	WeightForIndex      *float64  `json:"weight_for_index"`
+	ForeignSell         *float64  `json:"foreign_sell"`
+	ForeignBuy          *float64  `json:"foreign_buy"`
+	DelistingDate       *string   `json:"delisting_date"`
+	NonRegularVolume    *float64  `json:"non_regular_volume"`
+	NonRegularValue     *float64  `json:"non_regular_value"`
+	NonRegularFrequency *float64  `json:"non_regular_frequency"`
+	LastModified        time.Time `json:"last_modified"`
+}
+
+type SyncHistoryRequest struct {
+	Year  int `json:"year"`
+	Month int `json:"month"`
+	Day   int `json:"day"`
+}
+
+type PasardanaHistoryResponse struct {
+	Code                 string   `json:"Code"`
+	PrevClosingPrice     *float64 `json:"PrevClosingPrice"`
+	AdjustedClosingPrice *float64 `json:"AdjustedClosingPrice"`
+	AdjustedOpenPrice    *float64 `json:"AdjustedOpenPrice"`
+	AdjustedHighPrice    *float64 `json:"AdjustedHighPrice"`
+	AdjustedLowPrice     *float64 `json:"AdjustedLowPrice"`
+	Volume               *float64 `json:"Volume"`
+	Frequency            *float64 `json:"Frequency"`
+	Value                *float64 `json:"Value"`
+	LastDate             *string  `json:"LastDate"`
+}
+
+type IdxSummaryData struct {
+	Date                string   `json:"Date"`
+	StockCode           string   `json:"StockCode"`
+	Previous            *float64 `json:"Previous"`
+	OpenPrice           *float64 `json:"OpenPrice"`
+	FirstTrade          *float64 `json:"FirstTrade"`
+	High                *float64 `json:"High"`
+	Low                 *float64 `json:"Low"`
+	Close               *float64 `json:"Close"`
+	Change              *float64 `json:"Change"`
+	Volume              *float64 `json:"Volume"`
+	Value               *float64 `json:"Value"`
+	Frequency           *float64 `json:"Frequency"`
+	IndexIndividual     *float64 `json:"IndexIndividual"`
+	Offer               *float64 `json:"Offer"`
+	DelistingDate       string   `json:"DelistingDate"`
+	OfferVolume         *float64 `json:"OfferVolume"`
+	Bid                 *float64 `json:"Bid"`
+	BidVolume           *float64 `json:"BidVolume"`
+	ListedShares        *float64 `json:"ListedShares"`
+	TradebleShares      *float64 `json:"TradebleShares"`
+	WeightForIndex      *float64 `json:"WeightForIndex"`
+	ForeignSell         *float64 `json:"ForeignSell"`
+	ForeignBuy          *float64 `json:"ForeignBuy"`
+	NonRegularVolume    *float64 `json:"NonRegularVolume"`
+	NonRegularValue     *float64 `json:"NonRegularValue"`
+	NonRegularFrequency *float64 `json:"NonRegularFrequency"`
+}
+
+type IdxSummaryResponse struct {
+	Data []IdxSummaryData `json:"data"`
+}

--- a/internal/repositories/history_repository.go
+++ b/internal/repositories/history_repository.go
@@ -1,0 +1,146 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KAnggara75/IDXStocks/internal/models"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sirupsen/logrus"
+)
+
+type HistoryRepository interface {
+	BatchUpsertStockHistory(ctx context.Context, records []models.StockHistory) error
+}
+
+type historyRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewHistoryRepository(pool *pgxpool.Pool) HistoryRepository {
+	return &historyRepository{
+		pool: pool,
+	}
+}
+
+func (r *historyRepository) BatchUpsertStockHistory(ctx context.Context, records []models.StockHistory) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	query := `
+		INSERT INTO idxstock.history (
+			code, date, previous, open_price, first_trade, high, low, close, change,
+			volume, value, frequency, index_individual, offer, offer_volume,
+			bid, bid_volume, listed_shares, tradeble_shares, weight_for_index,
+			foreign_sell, foreign_buy, delisting_date, non_regular_volume,
+			non_regular_value, non_regular_frequency, last_modified
+		)
+		VALUES (
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+			$16, $17, $18, $19, $20, $21, $22, $23::DATE, $24, $25, $26, now()
+		)
+		ON CONFLICT (code, date) DO UPDATE SET
+			previous = EXCLUDED.previous,
+			open_price = EXCLUDED.open_price,
+			first_trade = EXCLUDED.first_trade,
+			high = EXCLUDED.high,
+			low = EXCLUDED.low,
+			close = EXCLUDED.close,
+			change = EXCLUDED.change,
+			volume = EXCLUDED.volume,
+			value = EXCLUDED.value,
+			frequency = EXCLUDED.frequency,
+			index_individual = EXCLUDED.index_individual,
+			offer = EXCLUDED.offer,
+			offer_volume = EXCLUDED.offer_volume,
+			bid = EXCLUDED.bid,
+			bid_volume = EXCLUDED.bid_volume,
+			listed_shares = EXCLUDED.listed_shares,
+			tradeble_shares = EXCLUDED.tradeble_shares,
+			weight_for_index = EXCLUDED.weight_for_index,
+			foreign_sell = EXCLUDED.foreign_sell,
+			foreign_buy = EXCLUDED.foreign_buy,
+			delisting_date = EXCLUDED.delisting_date,
+			non_regular_volume = EXCLUDED.non_regular_volume,
+			non_regular_value = EXCLUDED.non_regular_value,
+			non_regular_frequency = EXCLUDED.non_regular_frequency,
+			last_modified = now()
+		WHERE
+			history.previous IS DISTINCT FROM EXCLUDED.previous OR
+			history.open_price IS DISTINCT FROM EXCLUDED.open_price OR
+			history.first_trade IS DISTINCT FROM EXCLUDED.first_trade OR
+			history.high IS DISTINCT FROM EXCLUDED.high OR
+			history.low IS DISTINCT FROM EXCLUDED.low OR
+			history.close IS DISTINCT FROM EXCLUDED.close OR
+			history.change IS DISTINCT FROM EXCLUDED.change OR
+			history.volume IS DISTINCT FROM EXCLUDED.volume OR
+			history.value IS DISTINCT FROM EXCLUDED.value OR
+			history.frequency IS DISTINCT FROM EXCLUDED.frequency OR
+			history.index_individual IS DISTINCT FROM EXCLUDED.index_individual OR
+			history.offer IS DISTINCT FROM EXCLUDED.offer OR
+			history.offer_volume IS DISTINCT FROM EXCLUDED.offer_volume OR
+			history.bid IS DISTINCT FROM EXCLUDED.bid OR
+			history.bid_volume IS DISTINCT FROM EXCLUDED.bid_volume OR
+			history.listed_shares IS DISTINCT FROM EXCLUDED.listed_shares OR
+			history.tradeble_shares IS DISTINCT FROM EXCLUDED.tradeble_shares OR
+			history.weight_for_index IS DISTINCT FROM EXCLUDED.weight_for_index OR
+			history.foreign_sell IS DISTINCT FROM EXCLUDED.foreign_sell OR
+			history.foreign_buy IS DISTINCT FROM EXCLUDED.foreign_buy OR
+			history.delisting_date IS DISTINCT FROM EXCLUDED.delisting_date OR
+			history.non_regular_volume IS DISTINCT FROM EXCLUDED.non_regular_volume OR
+			history.non_regular_value IS DISTINCT FROM EXCLUDED.non_regular_value OR
+			history.non_regular_frequency IS DISTINCT FROM EXCLUDED.non_regular_frequency
+	`
+
+	batch := &pgx.Batch{}
+	for _, rec := range records {
+		var dd *string
+		if rec.DelistingDate != nil && *rec.DelistingDate != "" {
+			dd = rec.DelistingDate
+		}
+
+		batch.Queue(query,
+			rec.Code, rec.Date, rec.Previous, rec.OpenPrice, rec.FirstTrade,
+			rec.High, rec.Low, rec.Close, rec.Change, rec.Volume, rec.Value,
+			rec.Frequency, rec.IndexIndividual, rec.Offer, rec.OfferVolume,
+			rec.Bid, rec.BidVolume, rec.ListedShares, rec.TradebleShares,
+			rec.WeightForIndex, rec.ForeignSell, rec.ForeignBuy, dd,
+			rec.NonRegularVolume, rec.NonRegularValue, rec.NonRegularFrequency,
+		)
+	}
+
+	br := tx.SendBatch(ctx, batch)
+	defer br.Close()
+
+	var affected int64
+	for i := 0; i < len(records); i++ {
+		ct, err := br.Exec()
+		if err != nil {
+			// If it fails because of foreign key constraint, we might want to log it and continue
+			// but for now let's fail the whole batch to be safe, or just log.
+			// Actually history depends on stocks table.
+			logrus.Warnf("Failed to upsert history for %s on %s: %v", records[i].Code, records[i].Date.Format("2006-01-02"), err)
+			continue
+		}
+		affected += ct.RowsAffected()
+	}
+
+	if err := br.Close(); err != nil {
+		return fmt.Errorf("failed to close batch: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	logrus.Infof("Batch upsert completed. Affected rows: %d", affected)
+	return nil
+}

--- a/internal/repositories/stock_repository.go
+++ b/internal/repositories/stock_repository.go
@@ -15,6 +15,7 @@ type StockRepository interface {
 	UpdateStockIDs(ctx context.Context, data []models.PasardanaStock) ([]models.StockResponse, error)
 	UpsertStocksDetail(ctx context.Context, data []models.PasardanaStockDetail) ([]models.StockResponse, error)
 	UpdateDelistingDate(ctx context.Context, code, delistingDate string) (*models.StockResponse, error)
+	FindMissingCodes(ctx context.Context, codes []string) ([]string, error)
 }
 
 type stockRepository struct {
@@ -257,4 +258,32 @@ func (r *stockRepository) UpsertStocksDetail(ctx context.Context, data []models.
 	}
 
 	return updatedStocks, nil
+}
+func (r *stockRepository) FindMissingCodes(ctx context.Context, codes []string) ([]string, error) {
+	if len(codes) == 0 {
+		return nil, nil
+	}
+
+	query := `
+		SELECT c FROM (SELECT UNNEST($1::VARCHAR[]) as c) AS input
+		LEFT JOIN idxstock.stocks s ON input.c = s.code
+		WHERE s.code IS NULL
+	`
+
+	rows, err := r.pool.Query(ctx, query, codes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find missing codes: %w", err)
+	}
+	defer rows.Close()
+
+	var missingCodes []string
+	for rows.Next() {
+		var code string
+		if err := rows.Scan(&code); err != nil {
+			return nil, err
+		}
+		missingCodes = append(missingCodes, code)
+	}
+
+	return missingCodes, nil
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -14,6 +14,8 @@ func Setup(app *fiber.App) {
 	stockRepo := repositories.NewStockRepository(database.Pool)
 	sectorSearchRepo := repositories.NewSectorSearchRepository(database.Pool)
 	industryRepo := repositories.NewIndustryRepository(database.Pool)
+	historyRepo := repositories.NewHistoryRepository(database.Pool)
+
 	stockService := services.NewStockService()
 	pasardanaService := services.NewPasardanaService()
 	idxService := services.NewIdxService()
@@ -21,10 +23,12 @@ func Setup(app *fiber.App) {
 	stockUsecase := usecases.NewStockUsecase(stockRepo, stockService, pasardanaService, idxService)
 	industryUsecase := usecases.NewIndustryUsecase(industryRepo, pasardanaService)
 	sectorUsecase := usecases.NewSectorUsecase(sectorSearchRepo, pasardanaService)
+	historyUsecase := usecases.NewHistoryUsecase(historyRepo, pasardanaService, idxService)
 
 	stockHandler := handlers.NewStockHandler(stockUsecase)
 	industryHandler := handlers.NewIndustryHandler(industryUsecase)
 	sectorHandler := handlers.NewSectorHandler(sectorUsecase)
+	historyHandler := handlers.NewHistoryHandler(historyUsecase)
 
 	app.Get("/ping", func(c fiber.Ctx) error {
 		err := database.Pool.Ping(c.Context())
@@ -53,6 +57,7 @@ func Setup(app *fiber.App) {
 	v1.Put("/stocks/id", stockHandler.SyncIDHandler)
 	v1.Put("/stocks/sync", stockHandler.SyncStockDetailHandler)
 	v1.Put("/stocks/delisting/sync", stockHandler.SyncDelistingStocksHandler)
+	v1.Put("/stocks/history/sync", historyHandler.SyncStockHistoryHandler)
 	v1.Put("/sectors/sync", sectorHandler.SyncNewSectorsHandler)
 	v1.Put("/industries/sync", industryHandler.IndustrySyncHandler)
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -23,14 +23,14 @@ func Setup(app *fiber.App) {
 	stockUsecase := usecases.NewStockUsecase(stockRepo, stockService, pasardanaService, idxService)
 	industryUsecase := usecases.NewIndustryUsecase(industryRepo, pasardanaService)
 	sectorUsecase := usecases.NewSectorUsecase(sectorSearchRepo, pasardanaService)
-	historyUsecase := usecases.NewHistoryUsecase(historyRepo, pasardanaService, idxService)
+	historyUsecase := usecases.NewHistoryUsecase(historyRepo, stockRepo, pasardanaService, idxService)
 
 	stockHandler := handlers.NewStockHandler(stockUsecase)
 	industryHandler := handlers.NewIndustryHandler(industryUsecase)
 	sectorHandler := handlers.NewSectorHandler(sectorUsecase)
 	historyHandler := handlers.NewHistoryHandler(historyUsecase)
 
-	app.Get("/ping", func(c fiber.Ctx) error {
+	app.Get("/health", func(c fiber.Ctx) error {
 		err := database.Pool.Ping(c.Context())
 		if err != nil {
 			return c.Status(500).JSON(fiber.Map{
@@ -38,13 +38,6 @@ func Setup(app *fiber.App) {
 				"message": "database connection failed",
 			})
 		}
-		return c.JSON(fiber.Map{
-			"status":  "ok",
-			"message": "pong",
-		})
-	})
-
-	app.Get("/health", func(c fiber.Ctx) error {
 		return c.JSON(fiber.Map{
 			"status": "up",
 		})

--- a/internal/services/idx_service.go
+++ b/internal/services/idx_service.go
@@ -14,6 +14,7 @@ import (
 
 type IdxService interface {
 	FetchDelistedStocks(year, month int) ([]models.IdxDelistedStock, error)
+	FetchStockSummary(year, month, day int) ([]models.IdxSummaryData, error)
 	ParseIdxDate(dateStr string) (string, error)
 }
 
@@ -72,6 +73,46 @@ func (s *idxService) FetchDelistedStocks(year, month int) ([]models.IdxDelistedS
 	if err := json.Unmarshal(bodyBytes, &idxResp); err != nil {
 		logrus.Errorf("Failed to decode IDX response: %v", err)
 		return nil, fmt.Errorf("failed to decode IDX response: %w", err)
+	}
+
+	return idxResp.Data, nil
+}
+
+func (s *idxService) FetchStockSummary(year, month, day int) ([]models.IdxSummaryData, error) {
+	url := fmt.Sprintf("https://idx.co.id/primary/TradingSummary/GetStockSummary?date=%04d%02d%02d", year, month, day)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Add realistic browser headers
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36")
+	req.Header.Set("Accept", "application/json, text/plain, */*")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9,id;q=0.8")
+	req.Header.Set("Origin", "https://idx.co.id")
+	req.Header.Set("Referer", "https://idx.co.id/")
+	req.Header.Set("Connection", "keep-alive")
+
+	logrus.Infof("Requesting IDX Summary: %s", url)
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	// #nosec G107
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch from IDX: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("IDX API returned status: %d", resp.StatusCode)
+	}
+
+	var idxResp models.IdxSummaryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&idxResp); err != nil {
+		return nil, fmt.Errorf("failed to decode IDX summary response: %w", err)
 	}
 
 	return idxResp.Data, nil

--- a/internal/services/pasardana_service.go
+++ b/internal/services/pasardana_service.go
@@ -15,6 +15,7 @@ type PasardanaService interface {
 	FetchNewSectors() ([]models.PasardanaNewSector, error)
 	FetchNewSubSectors() ([]models.PasardanaNewSubSector, error)
 	FetchStockDetailByCode(code string) (*models.PasardanaStockDetail, error)
+	FetchStockHistory(year, month, day int) ([]models.PasardanaHistoryResponse, error)
 }
 
 type pasardanaService struct{}
@@ -66,6 +67,15 @@ func (s *pasardanaService) FetchStockDetailByCode(code string) (*models.Pasardan
 		return nil, err
 	}
 	return &result, nil
+}
+
+func (s *pasardanaService) FetchStockHistory(year, month, day int) ([]models.PasardanaHistoryResponse, error) {
+	url := fmt.Sprintf("https://www.pasardana.id/api/StockSearchResult/GetAll?date=%02d/%02d/%04d", month, day, year)
+	var results []models.PasardanaHistoryResponse
+	if err := s.fetch(url, &results); err != nil {
+		return nil, err
+	}
+	return results, nil
 }
 
 func (s *pasardanaService) fetch(url string, target any) error {

--- a/internal/usecases/history_usecase.go
+++ b/internal/usecases/history_usecase.go
@@ -1,0 +1,138 @@
+package usecases
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/KAnggara75/IDXStocks/internal/models"
+	"github.com/KAnggara75/IDXStocks/internal/repositories"
+	"github.com/KAnggara75/IDXStocks/internal/services"
+	"github.com/sirupsen/logrus"
+)
+
+type HistoryUsecase interface {
+	SyncStockHistory(ctx context.Context, req models.SyncHistoryRequest, source string) error
+}
+
+type historyUsecase struct {
+	repo             repositories.HistoryRepository
+	pasardanaService services.PasardanaService
+	idxService       services.IdxService
+}
+
+func NewHistoryUsecase(
+	repo repositories.HistoryRepository,
+	pasardanaService services.PasardanaService,
+	idxService services.IdxService,
+) HistoryUsecase {
+	return &historyUsecase{
+		repo:             repo,
+		pasardanaService: pasardanaService,
+		idxService:       idxService,
+	}
+}
+
+func (u *historyUsecase) SyncStockHistory(ctx context.Context, req models.SyncHistoryRequest, source string) error {
+	var records []models.StockHistory
+	targetDate := time.Date(req.Year, time.Month(req.Month), req.Day, 0, 0, 0, 0, time.Local)
+
+	switch source {
+	case "pasardana":
+		data, err := u.pasardanaService.FetchStockHistory(req.Year, req.Month, req.Day)
+		if err != nil {
+			return err
+		}
+		for _, d := range data {
+			// Parsing LastDate if provided, otherwise use targetDate
+			var date time.Time
+			if d.LastDate != nil && *d.LastDate != "" {
+				// Format expected: "2024-12-10T00:00:00"
+				t, err := time.Parse("2006-01-02T15:04:05", *d.LastDate)
+				if err == nil {
+					date = t
+				} else {
+					date = targetDate
+				}
+			} else {
+				date = targetDate
+			}
+
+			records = append(records, models.StockHistory{
+				Code:      d.Code,
+				Date:      date,
+				Previous:  d.PrevClosingPrice,
+				OpenPrice: d.AdjustedOpenPrice,
+				High:      d.AdjustedHighPrice,
+				Low:       d.AdjustedLowPrice,
+				Close:     d.AdjustedClosingPrice,
+				Volume:    d.Volume,
+				Frequency: d.Frequency,
+				Value:     d.Value,
+			})
+		}
+
+	case "idx":
+		data, err := u.idxService.FetchStockSummary(req.Year, req.Month, req.Day)
+		if err != nil {
+			return err
+		}
+		for _, d := range data {
+			var date time.Time
+			if d.Date != "" {
+				t, err := time.Parse("2006-01-02T15:04:05", d.Date)
+				if err == nil {
+					date = t
+				} else {
+					date = targetDate
+				}
+			} else {
+				date = targetDate
+			}
+
+			// DelistingDate mapping
+			var dd *string
+			if d.DelistingDate != "" {
+				dd = &d.DelistingDate
+			}
+
+			records = append(records, models.StockHistory{
+				Code:                d.StockCode,
+				Date:                date,
+				Previous:            d.Previous,
+				OpenPrice:           d.OpenPrice,
+				FirstTrade:          d.FirstTrade,
+				High:                d.High,
+				Low:                 d.Low,
+				Close:               d.Close,
+				Change:              d.Change,
+				Volume:              d.Volume,
+				Value:               d.Value,
+				Frequency:           d.Frequency,
+				IndexIndividual:     d.IndexIndividual,
+				Offer:               d.Offer,
+				OfferVolume:         d.OfferVolume,
+				Bid:                 d.Bid,
+				BidVolume:           d.BidVolume,
+				ListedShares:        d.ListedShares,
+				TradebleShares:      d.TradebleShares,
+				WeightForIndex:      d.WeightForIndex,
+				ForeignSell:         d.ForeignSell,
+				ForeignBuy:          d.ForeignBuy,
+				DelistingDate:       dd,
+				NonRegularVolume:    d.NonRegularVolume,
+				NonRegularValue:     d.NonRegularValue,
+				NonRegularFrequency: d.NonRegularFrequency,
+			})
+		}
+	default:
+		return fmt.Errorf("invalid source: %s", source)
+	}
+
+	if len(records) == 0 {
+		logrus.Warnf("No records found to sync for date %s from %s", targetDate.Format("2006-01-02"), source)
+		return nil
+	}
+
+	return u.repo.BatchUpsertStockHistory(ctx, records)
+}

--- a/internal/usecases/history_usecase.go
+++ b/internal/usecases/history_usecase.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KAnggara75/IDXStocks/internal/models"
 	"github.com/KAnggara75/IDXStocks/internal/repositories"
 	"github.com/KAnggara75/IDXStocks/internal/services"
+	"github.com/KAnggara75/IDXStocks/internal/utils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -17,17 +18,20 @@ type HistoryUsecase interface {
 
 type historyUsecase struct {
 	repo             repositories.HistoryRepository
+	stockRepo        repositories.StockRepository
 	pasardanaService services.PasardanaService
 	idxService       services.IdxService
 }
 
 func NewHistoryUsecase(
 	repo repositories.HistoryRepository,
+	stockRepo repositories.StockRepository,
 	pasardanaService services.PasardanaService,
 	idxService services.IdxService,
 ) HistoryUsecase {
 	return &historyUsecase{
 		repo:             repo,
+		stockRepo:        stockRepo,
 		pasardanaService: pasardanaService,
 		idxService:       idxService,
 	}
@@ -132,6 +136,63 @@ func (u *historyUsecase) SyncStockHistory(ctx context.Context, req models.SyncHi
 	if len(records) == 0 {
 		logrus.Warnf("No records found to sync for date %s from %s", targetDate.Format("2006-01-02"), source)
 		return nil
+	}
+
+	// Enhancement: Ensure all stock codes exist in DB before upserting history
+	codeMap := make(map[string]bool)
+	var codes []string
+	for _, r := range records {
+		if !codeMap[r.Code] {
+			codeMap[r.Code] = true
+			codes = append(codes, r.Code)
+		}
+	}
+
+	missingCodes, err := u.stockRepo.FindMissingCodes(ctx, codes)
+	if err != nil {
+		logrus.Errorf("Failed to identify missing codes: %v", err)
+	}
+
+	if len(missingCodes) > 0 {
+		logrus.Infof("Found %d missing stock codes, fetching from Pasardana...", len(missingCodes))
+		for _, code := range missingCodes {
+			detail, err := u.pasardanaService.FetchStockDetailByCode(code)
+			if err != nil {
+				logrus.Warnf("Failed to fetch detail for %s from Pasardana: %v", code, err)
+				continue
+			}
+
+			if detail != nil {
+				// Normalize dates with fallback to Epoch 0 (consistent with StockUsecase)
+				epoch0 := "1970-01-01"
+				if detail.ListingDate != nil && *detail.ListingDate != "" {
+					parsed := utils.NormalizeDate(*detail.ListingDate)
+					if parsed == "" {
+						parsed = epoch0
+					}
+					detail.ListingDate = &parsed
+				} else {
+					detail.ListingDate = &epoch0
+				}
+
+				if detail.FoundingDate != nil && *detail.FoundingDate != "" {
+					parsed := utils.NormalizeDate(*detail.FoundingDate)
+					if parsed == "" {
+						parsed = epoch0
+					}
+					detail.FoundingDate = &parsed
+				} else {
+					detail.FoundingDate = &epoch0
+				}
+
+				_, err = u.stockRepo.UpsertStocksDetail(ctx, []models.PasardanaStockDetail{*detail})
+				if err != nil {
+					logrus.Errorf("Failed to auto-insert missing stock %s: %v", code, err)
+					continue
+				}
+				logrus.Infof("Auto-inserted missing stock: %s", code)
+			}
+		}
 	}
 
 	return u.repo.BatchUpsertStockHistory(ctx, records)

--- a/migrations/004_create_history_table.sql
+++ b/migrations/004_create_history_table.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS idxstock.history (
+    code                  VARCHAR(10) NOT NULL,
+    date                  DATE        NOT NULL,
+    previous              NUMERIC,
+    open_price            NUMERIC,
+    first_trade           NUMERIC,
+    high                  NUMERIC,
+    low                   NUMERIC,
+    close                 NUMERIC,
+    change                NUMERIC,
+    volume                NUMERIC,
+    value                 NUMERIC,
+    frequency             NUMERIC,
+    index_individual      NUMERIC,
+    offer                 NUMERIC,
+    offer_volume          NUMERIC,
+    bid                   NUMERIC,
+    bid_volume            NUMERIC,
+    listed_shares         NUMERIC,
+    tradeble_shares       NUMERIC,
+    weight_for_index      NUMERIC,
+    foreign_sell          NUMERIC,
+    foreign_buy           NUMERIC,
+    delisting_date        DATE,
+    non_regular_volume    NUMERIC,
+    non_regular_value     NUMERIC,
+    non_regular_frequency NUMERIC,
+    last_modified         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (code, date),
+    CONSTRAINT fk_history_stock_code FOREIGN KEY (code) REFERENCES idxstock.stocks (code) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_history_code_like ON idxstock.history (code text_pattern_ops);
+CREATE INDEX IF NOT EXISTS idx_history_code_fk ON idxstock.history (code);
+CREATE INDEX IF NOT EXISTS idx_history_date ON idxstock.history (date);


### PR DESCRIPTION
Implement synchronization of daily stock history from both Pasardana and IDX sources. Users can select the source using the query parameter `?source=pasardana` (default) or `?source=idx`. The task covers database schema migration, unified models, service extensions, and batch processing for optimal performance. Resolves #25.