### PR TITLE
feat: stock history retrieval with JSON and CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # IDXStocks
+
+### Prompt
+
+buatkan issue.md yang berisi perencanaan untuk nanti di implementasikan oleh junior programmer atau ai model yang lebih murah
+
+isi dari planning nya sebagai berikut
+
+buat endpoint untuk get all histori berdasarkan stock code
+
+
+jelaskan tahpan-tahapan yangg harus dilakukan untuk implementasikan fitur ini, anggap nanti yang mengimplementasikan adalah junior programmer atau ai model yang lebih murah

--- a/internal/handlers/history_handler.go
+++ b/internal/handlers/history_handler.go
@@ -94,16 +94,10 @@ func (h *HistoryHandler) GetStockHistoryHandler(c fiber.Ctx) error {
 			requestedFields[i] = strings.ToLower(strings.TrimSpace(f))
 		}
 	} else {
-		// Default behavior using include_code
-		includeCode := c.Query("include_code", "false") == "true"
-		if includeCode {
-			requestedFields = allFields
-		} else {
-			// All fields except 'code' and 'last_modified' (to keep it clean)
-			for _, f := range allFields {
-				if f != "code" && f != "last_modified" {
-					requestedFields = append(requestedFields, f)
-				}
+		// Default fields (exclude code and last_modified)
+		for _, f := range allFields {
+			if f != "code" && f != "last_modified" {
+				requestedFields = append(requestedFields, f)
 			}
 		}
 	}

--- a/internal/handlers/history_handler.go
+++ b/internal/handlers/history_handler.go
@@ -63,6 +63,8 @@ func (h *HistoryHandler) GetStockHistoryHandler(c fiber.Ctx) error {
 	code := c.Params("code")
 	output := c.Query("output", "json")
 	fieldsRaw := c.Query("fields")
+	startDateRaw := c.Query("start_date")
+	endDateRaw := c.Query("end_date")
 
 	if code == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -70,7 +72,25 @@ func (h *HistoryHandler) GetStockHistoryHandler(c fiber.Ctx) error {
 		})
 	}
 
-	data, err := h.usecase.GetStockHistory(c.Context(), code)
+	var startDate, endDate *time.Time
+	if startDateRaw != "" {
+		t, err := time.Parse("2006-01-02", startDateRaw)
+		if err == nil {
+			startDate = &t
+		} else {
+			logrus.Warnf("Invalid start_date format: %s, expected YYYY-MM-DD", startDateRaw)
+		}
+	}
+	if endDateRaw != "" {
+		t, err := time.Parse("2006-01-02", endDateRaw)
+		if err == nil {
+			endDate = &t
+		} else {
+			logrus.Warnf("Invalid end_date format: %s, expected YYYY-MM-DD", endDateRaw)
+		}
+	}
+
+	data, err := h.usecase.GetStockHistory(c.Context(), code, startDate, endDate)
 	if err != nil {
 		logrus.Errorf("Failed to get stock history for %s: %v", code, err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{

--- a/internal/handlers/history_handler.go
+++ b/internal/handlers/history_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/KAnggara75/IDXStocks/internal/models"
 	"github.com/KAnggara75/IDXStocks/internal/usecases"
@@ -61,7 +62,7 @@ func (h *HistoryHandler) SyncStockHistoryHandler(c fiber.Ctx) error {
 func (h *HistoryHandler) GetStockHistoryHandler(c fiber.Ctx) error {
 	code := c.Params("code")
 	output := c.Query("output", "json")
-	includeCode := c.Query("include_code", "false") == "true"
+	fieldsRaw := c.Query("fields")
 
 	if code == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -77,58 +78,51 @@ func (h *HistoryHandler) GetStockHistoryHandler(c fiber.Ctx) error {
 		})
 	}
 
+	// Define all available fields and their getter/formatter
+	allFields := []string{
+		"code", "date", "previous", "open_price", "first_trade", "high", "low", "close", "change",
+		"volume", "value", "frequency", "index_individual", "offer", "offer_volume", "bid", "bid_volume",
+		"listed_shares", "tradeble_shares", "weight_for_index", "foreign_sell", "foreign_buy",
+		"delisting_date", "non_regular_volume", "non_regular_value", "non_regular_frequency", "last_modified",
+	}
+
+	var requestedFields []string
+	if fieldsRaw != "" {
+		requestedFields = strings.Split(fieldsRaw, ",")
+		// Trim spaces and lowercase
+		for i, f := range requestedFields {
+			requestedFields[i] = strings.ToLower(strings.TrimSpace(f))
+		}
+	} else {
+		// Default behavior using include_code
+		includeCode := c.Query("include_code", "false") == "true"
+		if includeCode {
+			requestedFields = allFields
+		} else {
+			// All fields except 'code' and 'last_modified' (to keep it clean)
+			for _, f := range allFields {
+				if f != "code" && f != "last_modified" {
+					requestedFields = append(requestedFields, f)
+				}
+			}
+		}
+	}
+
 	if output == "csv" {
 		c.Set("Content-Type", "text/csv")
 		c.Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.csv\"", strings.ToUpper(code)))
 
 		writer := csv.NewWriter(c)
 		// Write header
-		header := []string{}
-		if includeCode {
-			header = append(header, "code")
-		}
-		header = append(header,
-			"date", "previous", "open_price", "first_trade", "high", "low", "close", "change",
-			"volume", "value", "frequency", "index_individual", "offer", "offer_volume", "bid", "bid_volume",
-			"listed_shares", "tradeble_shares", "weight_for_index", "foreign_sell", "foreign_buy",
-			"delisting_date", "non_regular_volume", "non_regular_value", "non_regular_frequency",
-		)
-		if err := writer.Write(header); err != nil {
+		if err := writer.Write(requestedFields); err != nil {
 			return err
 		}
 
 		for _, row := range data {
-			line := []string{}
-			if includeCode {
-				line = append(line, row.Code)
+			line := make([]string, len(requestedFields))
+			for i, field := range requestedFields {
+				line[i] = getFieldAsString(row, field)
 			}
-			line = append(line,
-				row.Date.Format("2006-01-02"),
-				formatFloat(row.Previous),
-				formatFloat(row.OpenPrice),
-				formatFloat(row.FirstTrade),
-				formatFloat(row.High),
-				formatFloat(row.Low),
-				formatFloat(row.Close),
-				formatFloat(row.Change),
-				formatFloat(row.Volume),
-				formatFloat(row.Value),
-				formatFloat(row.Frequency),
-				formatFloat(row.IndexIndividual),
-				formatFloat(row.Offer),
-				formatFloat(row.OfferVolume),
-				formatFloat(row.Bid),
-				formatFloat(row.BidVolume),
-				formatFloat(row.ListedShares),
-				formatFloat(row.TradebleShares),
-				formatFloat(row.WeightForIndex),
-				formatFloat(row.ForeignSell),
-				formatFloat(row.ForeignBuy),
-				formatString(row.DelistingDate),
-				formatFloat(row.NonRegularVolume),
-				formatFloat(row.NonRegularValue),
-				formatFloat(row.NonRegularFrequency),
-			)
 			if err := writer.Write(line); err != nil {
 				return err
 			}
@@ -138,43 +132,138 @@ func (h *HistoryHandler) GetStockHistoryHandler(c fiber.Ctx) error {
 		return nil
 	}
 
-	if !includeCode {
-		// Strip 'code' from JSON response if requested
-		results := make([]map[string]any, len(data))
-		for i, v := range data {
-			results[i] = map[string]any{
-				"date":                  v.Date,
-				"previous":              v.Previous,
-				"open_price":            v.OpenPrice,
-				"first_trade":           v.FirstTrade,
-				"high":                  v.High,
-				"low":                   v.Low,
-				"close":                 v.Close,
-				"change":                v.Change,
-				"volume":                v.Volume,
-				"value":                 v.Value,
-				"frequency":             v.Frequency,
-				"index_individual":      v.IndexIndividual,
-				"offer":                 v.Offer,
-				"offer_volume":          v.OfferVolume,
-				"bid":                   v.Bid,
-				"bid_volume":            v.BidVolume,
-				"listed_shares":         v.ListedShares,
-				"tradeble_shares":       v.TradebleShares,
-				"weight_for_index":      v.WeightForIndex,
-				"foreign_sell":          v.ForeignSell,
-				"foreign_buy":           v.ForeignBuy,
-				"delisting_date":        v.DelistingDate,
-				"non_regular_volume":    v.NonRegularVolume,
-				"non_regular_value":     v.NonRegularValue,
-				"non_regular_frequency": v.NonRegularFrequency,
-				"last_modified":         v.LastModified,
-			}
+	// JSON Output
+	results := make([]map[string]any, len(data))
+	for i, row := range data {
+		results[i] = make(map[string]any)
+		for _, field := range requestedFields {
+			results[i][field] = getFieldValue(row, field)
 		}
-		return c.JSON(results)
 	}
 
-	return c.JSON(data)
+	return c.JSON(results)
+}
+
+func getFieldAsString(row models.StockHistory, field string) string {
+	switch field {
+	case "code":
+		return row.Code
+	case "date":
+		return row.Date.Format("2006-01-02")
+	case "previous":
+		return formatFloat(row.Previous)
+	case "open_price":
+		return formatFloat(row.OpenPrice)
+	case "first_trade":
+		return formatFloat(row.FirstTrade)
+	case "high":
+		return formatFloat(row.High)
+	case "low":
+		return formatFloat(row.Low)
+	case "close":
+		return formatFloat(row.Close)
+	case "change":
+		return formatFloat(row.Change)
+	case "volume":
+		return formatFloat(row.Volume)
+	case "value":
+		return formatFloat(row.Value)
+	case "frequency":
+		return formatFloat(row.Frequency)
+	case "index_individual":
+		return formatFloat(row.IndexIndividual)
+	case "offer":
+		return formatFloat(row.Offer)
+	case "offer_volume":
+		return formatFloat(row.OfferVolume)
+	case "bid":
+		return formatFloat(row.Bid)
+	case "bid_volume":
+		return formatFloat(row.BidVolume)
+	case "listed_shares":
+		return formatFloat(row.ListedShares)
+	case "tradeble_shares":
+		return formatFloat(row.TradebleShares)
+	case "weight_for_index":
+		return formatFloat(row.WeightForIndex)
+	case "foreign_sell":
+		return formatFloat(row.ForeignSell)
+	case "foreign_buy":
+		return formatFloat(row.ForeignBuy)
+	case "delisting_date":
+		return formatString(row.DelistingDate)
+	case "non_regular_volume":
+		return formatFloat(row.NonRegularVolume)
+	case "non_regular_value":
+		return formatFloat(row.NonRegularValue)
+	case "non_regular_frequency":
+		return formatFloat(row.NonRegularFrequency)
+	case "last_modified":
+		return row.LastModified.Format(time.RFC3339)
+	default:
+		return ""
+	}
+}
+
+func getFieldValue(row models.StockHistory, field string) any {
+	switch field {
+	case "code":
+		return row.Code
+	case "date":
+		return row.Date
+	case "previous":
+		return row.Previous
+	case "open_price":
+		return row.OpenPrice
+	case "first_trade":
+		return row.FirstTrade
+	case "high":
+		return row.High
+	case "low":
+		return row.Low
+	case "close":
+		return row.Close
+	case "change":
+		return row.Change
+	case "volume":
+		return row.Volume
+	case "value":
+		return row.Value
+	case "frequency":
+		return row.Frequency
+	case "index_individual":
+		return row.IndexIndividual
+	case "offer":
+		return row.Offer
+	case "offer_volume":
+		return row.OfferVolume
+	case "bid":
+		return row.Bid
+	case "bid_volume":
+		return row.BidVolume
+	case "listed_shares":
+		return row.ListedShares
+	case "tradeble_shares":
+		return row.TradebleShares
+	case "weight_for_index":
+		return row.WeightForIndex
+	case "foreign_sell":
+		return row.ForeignSell
+	case "foreign_buy":
+		return row.ForeignBuy
+	case "delisting_date":
+		return row.DelistingDate
+	case "non_regular_volume":
+		return row.NonRegularVolume
+	case "non_regular_value":
+		return row.NonRegularValue
+	case "non_regular_frequency":
+		return row.NonRegularFrequency
+	case "last_modified":
+		return row.LastModified
+	default:
+		return nil
+	}
 }
 
 func formatFloat(f *float64) string {

--- a/internal/handlers/history_handler.go
+++ b/internal/handlers/history_handler.go
@@ -59,7 +59,7 @@ func (h *HistoryHandler) SyncStockHistoryHandler(c fiber.Ctx) error {
 	})
 }
 func (h *HistoryHandler) GetStockHistoryHandler(c fiber.Ctx) error {
-	code := c.Query("code")
+	code := c.Params("code")
 	output := c.Query("output", "json")
 	includeCode := c.Query("include_code", "false") == "true"
 

--- a/internal/handlers/history_handler.go
+++ b/internal/handlers/history_handler.go
@@ -61,6 +61,7 @@ func (h *HistoryHandler) SyncStockHistoryHandler(c fiber.Ctx) error {
 func (h *HistoryHandler) GetStockHistoryHandler(c fiber.Ctx) error {
 	code := c.Query("code")
 	output := c.Query("output", "json")
+	includeCode := c.Query("include_code", "false") == "true"
 
 	if code == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -78,23 +79,30 @@ func (h *HistoryHandler) GetStockHistoryHandler(c fiber.Ctx) error {
 
 	if output == "csv" {
 		c.Set("Content-Type", "text/csv")
-		c.Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"history_%s.csv\"", strings.ToLower(code)))
+		c.Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.csv\"", strings.ToUpper(code)))
 
 		writer := csv.NewWriter(c)
 		// Write header
-		header := []string{
-			"code", "date", "previous", "open_price", "first_trade", "high", "low", "close", "change",
+		header := []string{}
+		if includeCode {
+			header = append(header, "code")
+		}
+		header = append(header,
+			"date", "previous", "open_price", "first_trade", "high", "low", "close", "change",
 			"volume", "value", "frequency", "index_individual", "offer", "offer_volume", "bid", "bid_volume",
 			"listed_shares", "tradeble_shares", "weight_for_index", "foreign_sell", "foreign_buy",
 			"delisting_date", "non_regular_volume", "non_regular_value", "non_regular_frequency",
-		}
+		)
 		if err := writer.Write(header); err != nil {
 			return err
 		}
 
 		for _, row := range data {
-			line := []string{
-				row.Code,
+			line := []string{}
+			if includeCode {
+				line = append(line, row.Code)
+			}
+			line = append(line,
 				row.Date.Format("2006-01-02"),
 				formatFloat(row.Previous),
 				formatFloat(row.OpenPrice),
@@ -120,7 +128,7 @@ func (h *HistoryHandler) GetStockHistoryHandler(c fiber.Ctx) error {
 				formatFloat(row.NonRegularVolume),
 				formatFloat(row.NonRegularValue),
 				formatFloat(row.NonRegularFrequency),
-			}
+			)
 			if err := writer.Write(line); err != nil {
 				return err
 			}
@@ -128,6 +136,42 @@ func (h *HistoryHandler) GetStockHistoryHandler(c fiber.Ctx) error {
 
 		writer.Flush()
 		return nil
+	}
+
+	if !includeCode {
+		// Strip 'code' from JSON response if requested
+		results := make([]map[string]any, len(data))
+		for i, v := range data {
+			results[i] = map[string]any{
+				"date":                  v.Date,
+				"previous":              v.Previous,
+				"open_price":            v.OpenPrice,
+				"first_trade":           v.FirstTrade,
+				"high":                  v.High,
+				"low":                   v.Low,
+				"close":                 v.Close,
+				"change":                v.Change,
+				"volume":                v.Volume,
+				"value":                 v.Value,
+				"frequency":             v.Frequency,
+				"index_individual":      v.IndexIndividual,
+				"offer":                 v.Offer,
+				"offer_volume":          v.OfferVolume,
+				"bid":                   v.Bid,
+				"bid_volume":            v.BidVolume,
+				"listed_shares":         v.ListedShares,
+				"tradeble_shares":       v.TradebleShares,
+				"weight_for_index":      v.WeightForIndex,
+				"foreign_sell":          v.ForeignSell,
+				"foreign_buy":           v.ForeignBuy,
+				"delisting_date":        v.DelistingDate,
+				"non_regular_volume":    v.NonRegularVolume,
+				"non_regular_value":     v.NonRegularValue,
+				"non_regular_frequency": v.NonRegularFrequency,
+				"last_modified":         v.LastModified,
+			}
+		}
+		return c.JSON(results)
 	}
 
 	return c.JSON(data)

--- a/internal/handlers/history_handler.go
+++ b/internal/handlers/history_handler.go
@@ -1,6 +1,10 @@
 package handlers
 
 import (
+	"encoding/csv"
+	"fmt"
+	"strings"
+
 	"github.com/KAnggara75/IDXStocks/internal/models"
 	"github.com/KAnggara75/IDXStocks/internal/usecases"
 	"github.com/gofiber/fiber/v3"
@@ -53,4 +57,92 @@ func (h *HistoryHandler) SyncStockHistoryHandler(c fiber.Ctx) error {
 		"date":    req,
 		"source":  source,
 	})
+}
+func (h *HistoryHandler) GetStockHistoryHandler(c fiber.Ctx) error {
+	code := c.Query("code")
+	output := c.Query("output", "json")
+
+	if code == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Code is required",
+		})
+	}
+
+	data, err := h.usecase.GetStockHistory(c.Context(), code)
+	if err != nil {
+		logrus.Errorf("Failed to get stock history for %s: %v", code, err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+
+	if output == "csv" {
+		c.Set("Content-Type", "text/csv")
+		c.Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"history_%s.csv\"", strings.ToLower(code)))
+
+		writer := csv.NewWriter(c)
+		// Write header
+		header := []string{
+			"code", "date", "previous", "open_price", "first_trade", "high", "low", "close", "change",
+			"volume", "value", "frequency", "index_individual", "offer", "offer_volume", "bid", "bid_volume",
+			"listed_shares", "tradeble_shares", "weight_for_index", "foreign_sell", "foreign_buy",
+			"delisting_date", "non_regular_volume", "non_regular_value", "non_regular_frequency",
+		}
+		if err := writer.Write(header); err != nil {
+			return err
+		}
+
+		for _, row := range data {
+			line := []string{
+				row.Code,
+				row.Date.Format("2006-01-02"),
+				formatFloat(row.Previous),
+				formatFloat(row.OpenPrice),
+				formatFloat(row.FirstTrade),
+				formatFloat(row.High),
+				formatFloat(row.Low),
+				formatFloat(row.Close),
+				formatFloat(row.Change),
+				formatFloat(row.Volume),
+				formatFloat(row.Value),
+				formatFloat(row.Frequency),
+				formatFloat(row.IndexIndividual),
+				formatFloat(row.Offer),
+				formatFloat(row.OfferVolume),
+				formatFloat(row.Bid),
+				formatFloat(row.BidVolume),
+				formatFloat(row.ListedShares),
+				formatFloat(row.TradebleShares),
+				formatFloat(row.WeightForIndex),
+				formatFloat(row.ForeignSell),
+				formatFloat(row.ForeignBuy),
+				formatString(row.DelistingDate),
+				formatFloat(row.NonRegularVolume),
+				formatFloat(row.NonRegularValue),
+				formatFloat(row.NonRegularFrequency),
+			}
+			if err := writer.Write(line); err != nil {
+				return err
+			}
+		}
+
+		writer.Flush()
+		return nil
+	}
+
+	return c.JSON(data)
+}
+
+func formatFloat(f *float64) string {
+	if f == nil {
+		return "0.0"
+	}
+	return fmt.Sprintf("%.1f", *f)
+}
+
+func formatString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }

--- a/internal/repositories/history_repository.go
+++ b/internal/repositories/history_repository.go
@@ -12,6 +12,7 @@ import (
 
 type HistoryRepository interface {
 	BatchUpsertStockHistory(ctx context.Context, records []models.StockHistory) error
+	GetHistoryByCode(ctx context.Context, code string) ([]models.StockHistory, error)
 }
 
 type historyRepository struct {
@@ -143,4 +144,42 @@ func (r *historyRepository) BatchUpsertStockHistory(ctx context.Context, records
 
 	logrus.Infof("Batch upsert completed. Affected rows: %d", affected)
 	return nil
+}
+func (r *historyRepository) GetHistoryByCode(ctx context.Context, code string) ([]models.StockHistory, error) {
+	query := `
+		SELECT
+			code, date, previous, open_price, first_trade, high, low, close, change,
+			volume, value, frequency, index_individual, offer, offer_volume,
+			bid, bid_volume, listed_shares, tradeble_shares, weight_for_index,
+			foreign_sell, foreign_buy, delisting_date, non_regular_volume,
+			non_regular_value, non_regular_frequency, last_modified
+		FROM idxstock.history
+		WHERE code = $1
+		ORDER BY date ASC
+	`
+
+	rows, err := r.pool.Query(ctx, query, code)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get history for %s: %w", code, err)
+	}
+	defer rows.Close()
+
+	var records []models.StockHistory
+	for rows.Next() {
+		var h models.StockHistory
+		err := rows.Scan(
+			&h.Code, &h.Date, &h.Previous, &h.OpenPrice, &h.FirstTrade,
+			&h.High, &h.Low, &h.Close, &h.Change, &h.Volume, &h.Value,
+			&h.Frequency, &h.IndexIndividual, &h.Offer, &h.OfferVolume,
+			&h.Bid, &h.BidVolume, &h.ListedShares, &h.TradebleShares,
+			&h.WeightForIndex, &h.ForeignSell, &h.ForeignBuy, &h.DelistingDate,
+			&h.NonRegularVolume, &h.NonRegularValue, &h.NonRegularFrequency, &h.LastModified,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan history record: %w", err)
+		}
+		records = append(records, h)
+	}
+
+	return records, nil
 }

--- a/internal/repositories/history_repository.go
+++ b/internal/repositories/history_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/KAnggara75/IDXStocks/internal/models"
 	"github.com/jackc/pgx/v5"
@@ -12,7 +13,7 @@ import (
 
 type HistoryRepository interface {
 	BatchUpsertStockHistory(ctx context.Context, records []models.StockHistory) error
-	GetHistoryByCode(ctx context.Context, code string) ([]models.StockHistory, error)
+	GetHistoryByCode(ctx context.Context, code string, startDate, endDate *time.Time) ([]models.StockHistory, error)
 }
 
 type historyRepository struct {
@@ -145,7 +146,7 @@ func (r *historyRepository) BatchUpsertStockHistory(ctx context.Context, records
 	logrus.Infof("Batch upsert completed. Affected rows: %d", affected)
 	return nil
 }
-func (r *historyRepository) GetHistoryByCode(ctx context.Context, code string) ([]models.StockHistory, error) {
+func (r *historyRepository) GetHistoryByCode(ctx context.Context, code string, startDate, endDate *time.Time) ([]models.StockHistory, error) {
 	query := `
 		SELECT
 			code, date, previous, open_price, first_trade, high, low, close, change,
@@ -155,10 +156,12 @@ func (r *historyRepository) GetHistoryByCode(ctx context.Context, code string) (
 			non_regular_value, non_regular_frequency, last_modified
 		FROM idxstock.history
 		WHERE code = $1
+			AND ($2::DATE IS NULL OR date >= $2)
+			AND ($3::DATE IS NULL OR date <= $3)
 		ORDER BY date ASC
 	`
 
-	rows, err := r.pool.Query(ctx, query, code)
+	rows, err := r.pool.Query(ctx, query, code, startDate, endDate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get history for %s: %w", code, err)
 	}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -51,6 +51,7 @@ func Setup(app *fiber.App) {
 	v1.Put("/stocks/sync", stockHandler.SyncStockDetailHandler)
 	v1.Put("/stocks/delisting/sync", stockHandler.SyncDelistingStocksHandler)
 	v1.Put("/stocks/history/sync", historyHandler.SyncStockHistoryHandler)
+	v1.Get("/stocks/history", historyHandler.GetStockHistoryHandler)
 	v1.Put("/sectors/sync", sectorHandler.SyncNewSectorsHandler)
 	v1.Put("/industries/sync", industryHandler.IndustrySyncHandler)
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -51,7 +51,7 @@ func Setup(app *fiber.App) {
 	v1.Put("/stocks/sync", stockHandler.SyncStockDetailHandler)
 	v1.Put("/stocks/delisting/sync", stockHandler.SyncDelistingStocksHandler)
 	v1.Put("/stocks/history/sync", historyHandler.SyncStockHistoryHandler)
-	v1.Get("/stocks/history", historyHandler.GetStockHistoryHandler)
+	v1.Get("/stocks/:code/history", historyHandler.GetStockHistoryHandler)
 	v1.Put("/sectors/sync", sectorHandler.SyncNewSectorsHandler)
 	v1.Put("/industries/sync", industryHandler.IndustrySyncHandler)
 }

--- a/internal/usecases/history_usecase.go
+++ b/internal/usecases/history_usecase.go
@@ -15,7 +15,7 @@ import (
 
 type HistoryUsecase interface {
 	SyncStockHistory(ctx context.Context, req models.SyncHistoryRequest, source string) error
-	GetStockHistory(ctx context.Context, code string) ([]models.StockHistory, error)
+	GetStockHistory(ctx context.Context, code string, startDate, endDate *time.Time) ([]models.StockHistory, error)
 }
 
 type historyUsecase struct {
@@ -199,7 +199,7 @@ func (u *historyUsecase) SyncStockHistory(ctx context.Context, req models.SyncHi
 
 	return u.repo.BatchUpsertStockHistory(ctx, records)
 }
-func (u *historyUsecase) GetStockHistory(ctx context.Context, code string) ([]models.StockHistory, error) {
+func (u *historyUsecase) GetStockHistory(ctx context.Context, code string, startDate, endDate *time.Time) ([]models.StockHistory, error) {
 	code = strings.ToUpper(code)
-	return u.repo.GetHistoryByCode(ctx, code)
+	return u.repo.GetHistoryByCode(ctx, code, startDate, endDate)
 }

--- a/internal/usecases/history_usecase.go
+++ b/internal/usecases/history_usecase.go
@@ -3,6 +3,7 @@ package usecases
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/KAnggara75/IDXStocks/internal/models"
@@ -14,6 +15,7 @@ import (
 
 type HistoryUsecase interface {
 	SyncStockHistory(ctx context.Context, req models.SyncHistoryRequest, source string) error
+	GetStockHistory(ctx context.Context, code string) ([]models.StockHistory, error)
 }
 
 type historyUsecase struct {
@@ -196,4 +198,8 @@ func (u *historyUsecase) SyncStockHistory(ctx context.Context, req models.SyncHi
 	}
 
 	return u.repo.BatchUpsertStockHistory(ctx, records)
+}
+func (u *historyUsecase) GetStockHistory(ctx context.Context, code string) ([]models.StockHistory, error) {
+	code = strings.ToUpper(code)
+	return u.repo.GetHistoryByCode(ctx, code)
 }


### PR DESCRIPTION
Implement the new endpoint GET /api/v1/stocks/history to retrieve all historical data for a specific stock code. The endpoint supports both JSON (default) and CSV outputs via the `?output=csv` query parameter. Includes repository query methods, usecase normalization, and a dedicated CSV generator in the handler. Resolves #27.