### PR TITLE
fix(security): resolve gosec G118 in stock sync handler

### DIFF
--- a/internal/handlers/stock_handler.go
+++ b/internal/handlers/stock_handler.go
@@ -98,12 +98,12 @@ func (h *StockHandler) SyncIDHandler(c fiber.Ctx) error {
 
 func (h *StockHandler) SyncStockDetailHandler(c fiber.Ctx) error {
 	// Run synchronization in background
-	go func() {
-		_, err := h.usecase.SyncStockDetail(context.Background())
+	go func(ctx context.Context) {
+		_, err := h.usecase.SyncStockDetail(ctx)
 		if err != nil {
 			logrus.Errorf("Background stock sync failed: %v", err)
 		}
-	}()
+	}(context.WithoutCancel(c.Context()))
 
 	return c.JSON(fiber.Map{
 		"status":  "success",


### PR DESCRIPTION
This PR fixes the G118 security warning flagged by gosec. The fix replaces context.Background with context.WithoutCancel(c.Context()) in the background goroutine.