### PR TITLE
chore: optimize and upgrade github workflows

### DIFF
--- a/.github/workflows/dependabot-go.yaml
+++ b/.github/workflows/dependabot-go.yaml
@@ -3,7 +3,7 @@ name: "Dependabot: Update go.sum"
 on:
   pull_request:
     paths:
-      - '**/go.mod'
+      - 'go.mod'
 
 permissions:
   contents: write
@@ -15,15 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Dependabot PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.4.0
         with:
-          go-version: '1.24.4'
+          go-version: "1.26.2"
+          cache: true
       - name: Update Go sum
         run: |
           go mod tidy

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: "Dependency Review"
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v4.9.0
         with:
           comment-summary-in-pr: always

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-go@v6.4.0
         with:
           go-version: "1.26.2"
+          cache: true
 
       - name: Install tools
         run: |


### PR DESCRIPTION
This PR optimizes and upgrades GitHub Actions workflows:
1. Upgraded actions/checkout to v6.0.2 in multiple workflows.
2. Upgraded actions/setup-go to v6.4.0 and enabled 'cache: true' for better performance.
3. Updated Go version to 1.26.2 in dependabot-go workflow.
4. Updated actions/dependency-review-action to v4.9.0.
5. Optimized path trigger in dependabot-go workflow.