### PR TITLE
feat: implement automated weekly partition management

### DIFF
--- a/internal/handlers/asset_handler.go
+++ b/internal/handlers/asset_handler.go
@@ -1,0 +1,76 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/sirupsen/logrus"
+)
+
+type AssetHandler struct{}
+
+func NewAssetHandler() *AssetHandler {
+	return &AssetHandler{}
+}
+
+func (h *AssetHandler) GetCompanyLogo(c fiber.Ctx) error {
+	code := c.Params("code")
+	if code == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "code is required",
+		})
+	}
+
+	// Remove .png suffix if present (case insensitive) and normalize to uppercase
+	code = strings.TrimSuffix(strings.ToUpper(code), ".PNG")
+
+	targetURL := fmt.Sprintf("https://assets.stockbit.com/logos/companies/%s.png", code)
+
+	client := &http.Client{
+		Timeout: 15 * time.Second,
+	}
+
+	req, err := http.NewRequestWithContext(c.Context(), "GET", targetURL, nil)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to create request",
+		})
+	}
+
+	// Add realistic user agent
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		logrus.Errorf("Failed to proxy logo for %s: %v", code, err)
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "failed to fetch logo from source",
+		})
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusNotFound {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+				"error": "logo not found",
+			})
+		}
+		return c.Status(resp.StatusCode).JSON(fiber.Map{
+			"error": fmt.Sprintf("source returned status %d", resp.StatusCode),
+		})
+	}
+
+	// Set response headers from the source
+	c.Set("Content-Type", resp.Header.Get("Content-Type"))
+	if contentLength := resp.Header.Get("Content-Length"); contentLength != "" {
+		c.Set("Content-Length", contentLength)
+	}
+	// Add caching headers to reduce future proxy requests
+	c.Set("Cache-Control", "public, max-age=86400")
+
+	// c.SendStream will read from resp.Body and close it when done
+	return c.SendStream(resp.Body)
+}

--- a/internal/handlers/broker_handler.go
+++ b/internal/handlers/broker_handler.go
@@ -42,3 +42,23 @@ func (h *BrokerHandler) SyncBrokerActivityHandler(c fiber.Ctx) error {
 
 	return c.JSON(activities)
 }
+
+func (h *BrokerHandler) ManagePartitionsHandler(c fiber.Ctx) error {
+	resp, err := h.usecase.ManagePartitions(c.Context())
+	if err != nil {
+		logrus.Errorf("Partition management error: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+
+	status := fiber.StatusOK
+	if resp.PartitionsCreated > 0 {
+		status = fiber.StatusCreated
+	}
+
+	return c.Status(status).JSON(fiber.Map{
+		"status": "success",
+		"data":   resp,
+	})
+}

--- a/internal/handlers/broker_handler.go
+++ b/internal/handlers/broker_handler.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	"github.com/KAnggara75/IDXStocks/internal/models"
+	"github.com/KAnggara75/IDXStocks/internal/usecases"
+	"github.com/gofiber/fiber/v3"
+	"github.com/sirupsen/logrus"
+)
+
+type BrokerHandler struct {
+	usecase usecases.BrokerUsecase
+}
+
+func NewBrokerHandler(usecase usecases.BrokerUsecase) *BrokerHandler {
+	return &BrokerHandler{
+		usecase: usecase,
+	}
+}
+
+func (h *BrokerHandler) SyncBrokerActivityHandler(c fiber.Ctx) error {
+	var params models.SyncBrokerActivityParams
+	if err := c.Bind().Query(&params); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Failed to parse query parameters",
+		})
+	}
+
+	token := c.Get("Authorization")
+	if token == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "Authorization header is required",
+		})
+	}
+
+	activities, err := h.usecase.SyncBrokerActivity(c.Context(), token, params)
+	if err != nil {
+		logrus.Errorf("Broker activity sync error: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+
+	return c.JSON(activities)
+}

--- a/internal/models/broker_activity.go
+++ b/internal/models/broker_activity.go
@@ -41,3 +41,14 @@ type SyncBrokerActivityParams struct {
 	MarketBoard     string `query:"market_board"`
 	InvestorType    string `query:"investor_type"`
 }
+
+type PartitionDetail struct {
+	Name   string `json:"name"`
+	Status string `json:"status"` // "created" or "exists"
+	Range  string `json:"range"`
+}
+
+type PartitionManagementResponse struct {
+	PartitionsCreated int               `json:"partitions_created"`
+	Details           []PartitionDetail `json:"details"`
+}

--- a/internal/models/broker_activity.go
+++ b/internal/models/broker_activity.go
@@ -17,8 +17,8 @@ type ExodusBrokerActivityItem struct {
 	StockCode  string  `json:"stock_code"`
 	BrokerCode string  `json:"broker_code"`
 	Date       string  `json:"date"`
-	Value      int64   `json:"value"`
-	Lot        int64   `json:"lot"`
+	Value      float64 `json:"value"`
+	Lot        float64 `json:"lot"`
 	AvgPrice   float64 `json:"avg_price"`
 	Freq       int64   `json:"freq"`
 }

--- a/internal/models/broker_activity.go
+++ b/internal/models/broker_activity.go
@@ -1,0 +1,43 @@
+package models
+
+import "time"
+
+type BrokerActivity struct {
+	BrokerCode string    `json:"broker_code" db:"broker_code"`
+	StockCode  string    `json:"stock_code" db:"stock_code"`
+	Date       time.Time `json:"date" db:"date"`
+	Side       string    `json:"side" db:"side"` // "buy" or "sell"
+	Lot        int64     `json:"lot" db:"lot"`
+	Value      int64     `json:"value" db:"value"`
+	AvgPrice   float64   `json:"avg_price" db:"avg_price"`
+	Freq       int64     `json:"freq" db:"freq"`
+}
+
+type ExodusBrokerActivityItem struct {
+	StockCode  string  `json:"stock_code"`
+	BrokerCode string  `json:"broker_code"`
+	Date       string  `json:"date"`
+	Value      int64   `json:"value"`
+	Lot        int64   `json:"lot"`
+	AvgPrice   float64 `json:"avg_price"`
+	Freq       int64   `json:"freq"`
+}
+
+type ExodusBrokerActivityResponse struct {
+	Message string `json:"message"`
+	Data    struct {
+		BrokerActivityTransaction struct {
+			BrokersBuy  []ExodusBrokerActivityItem `json:"brokers_buy"`
+			BrokersSell []ExodusBrokerActivityItem `json:"brokers_sell"`
+		} `json:"broker_activity_transaction"`
+	} `json:"data"`
+}
+
+type SyncBrokerActivityParams struct {
+	BrokerCode      string `query:"broker_code"`
+	From            string `query:"from"`
+	To              string `query:"to"`
+	TransactionType string `query:"transaction_type"`
+	MarketBoard     string `query:"market_board"`
+	InvestorType    string `query:"investor_type"`
+}

--- a/internal/repositories/broker_activity_repository.go
+++ b/internal/repositories/broker_activity_repository.go
@@ -13,6 +13,8 @@ import (
 type BrokerActivityRepository interface {
 	BatchInsertBrokerActivity(ctx context.Context, records []models.BrokerActivity) error
 	InsertBrokerActivity(ctx context.Context, record models.BrokerActivity) (bool, error)
+	CheckPartitionExists(ctx context.Context, tableName string) (bool, error)
+	CreatePartition(ctx context.Context, tableName, startDate, endDate string) error
 }
 
 type brokerActivityRepository struct {
@@ -105,4 +107,35 @@ func (r *brokerActivityRepository) InsertBrokerActivity(ctx context.Context, rec
 	}
 
 	return ct.RowsAffected() > 0, nil
+}
+
+func (r *brokerActivityRepository) CheckPartitionExists(ctx context.Context, tableName string) (bool, error) {
+	query := `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.tables
+			WHERE table_schema = 'idxstock' AND table_name = $1
+		)
+	`
+	var exists bool
+	err := r.pool.QueryRow(ctx, query, tableName).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("failed to check partition existence for %s: %w", tableName, err)
+	}
+	return exists, nil
+}
+
+func (r *brokerActivityRepository) CreatePartition(ctx context.Context, tableName, startDate, endDate string) error {
+	// DDL statements cannot use parameters for table names, so we use fmt.Sprintf
+	// We assume tableName is internally generated and safe.
+	query := fmt.Sprintf(`
+		CREATE TABLE idxstock.%s PARTITION OF idxstock.broker_activity
+		FOR VALUES FROM ('%s') TO ('%s')
+	`, tableName, startDate, endDate)
+
+	_, err := r.pool.Exec(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to create partition %s [%s to %s]: %w", tableName, startDate, endDate, err)
+	}
+
+	return nil
 }

--- a/internal/repositories/broker_activity_repository.go
+++ b/internal/repositories/broker_activity_repository.go
@@ -12,6 +12,7 @@ import (
 
 type BrokerActivityRepository interface {
 	BatchUpsertBrokerActivity(ctx context.Context, records []models.BrokerActivity) error
+	UpsertBrokerActivity(ctx context.Context, record models.BrokerActivity) error
 }
 
 type brokerActivityRepository struct {
@@ -82,5 +83,36 @@ func (r *brokerActivityRepository) BatchUpsertBrokerActivity(ctx context.Context
 	}
 
 	logrus.Infof("Successfully upserted %d broker activity records (affected: %d)", len(records), affected)
+	return nil
+}
+
+func (r *brokerActivityRepository) UpsertBrokerActivity(ctx context.Context, rec models.BrokerActivity) error {
+	query := `
+		INSERT INTO idxstock.broker_activity (
+			broker_code, stock_code, date, side, lot, value, avg_price, freq, updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
+		ON CONFLICT (broker_code, stock_code, date, side) DO UPDATE SET
+			lot = EXCLUDED.lot,
+			value = EXCLUDED.value,
+			avg_price = EXCLUDED.avg_price,
+			freq = EXCLUDED.freq,
+			updated_at = now()
+		WHERE
+			idxstock.broker_activity.lot IS DISTINCT FROM EXCLUDED.lot OR
+			idxstock.broker_activity.value IS DISTINCT FROM EXCLUDED.value OR
+			idxstock.broker_activity.avg_price IS DISTINCT FROM EXCLUDED.avg_price OR
+			idxstock.broker_activity.freq IS DISTINCT FROM EXCLUDED.freq
+	`
+
+	_, err := r.pool.Exec(ctx, query,
+		rec.BrokerCode, rec.StockCode, rec.Date, rec.Side,
+		rec.Lot, rec.Value, rec.AvgPrice, rec.Freq,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to upsert broker activity (%s, %s, %s, %s): %w",
+			rec.BrokerCode, rec.StockCode, rec.Date.Format("2006-01-02"), rec.Side, err)
+	}
+
 	return nil
 }

--- a/internal/repositories/broker_activity_repository.go
+++ b/internal/repositories/broker_activity_repository.go
@@ -11,8 +11,8 @@ import (
 )
 
 type BrokerActivityRepository interface {
-	BatchUpsertBrokerActivity(ctx context.Context, records []models.BrokerActivity) error
-	UpsertBrokerActivity(ctx context.Context, record models.BrokerActivity) (bool, error)
+	BatchInsertBrokerActivity(ctx context.Context, records []models.BrokerActivity) error
+	InsertBrokerActivity(ctx context.Context, record models.BrokerActivity) (bool, error)
 }
 
 type brokerActivityRepository struct {
@@ -25,7 +25,7 @@ func NewBrokerActivityRepository(pool *pgxpool.Pool) BrokerActivityRepository {
 	}
 }
 
-func (r *brokerActivityRepository) BatchUpsertBrokerActivity(ctx context.Context, records []models.BrokerActivity) error {
+func (r *brokerActivityRepository) BatchInsertBrokerActivity(ctx context.Context, records []models.BrokerActivity) error {
 	if len(records) == 0 {
 		return nil
 	}
@@ -86,7 +86,7 @@ func (r *brokerActivityRepository) BatchUpsertBrokerActivity(ctx context.Context
 	return nil
 }
 
-func (r *brokerActivityRepository) UpsertBrokerActivity(ctx context.Context, rec models.BrokerActivity) (bool, error) {
+func (r *brokerActivityRepository) InsertBrokerActivity(ctx context.Context, rec models.BrokerActivity) (bool, error) {
 	query := `
 		INSERT INTO idxstock.broker_activity (
 			broker_code, stock_code, date, side, lot, value, avg_price, freq, updated_at

--- a/internal/repositories/broker_activity_repository.go
+++ b/internal/repositories/broker_activity_repository.go
@@ -12,7 +12,7 @@ import (
 
 type BrokerActivityRepository interface {
 	BatchUpsertBrokerActivity(ctx context.Context, records []models.BrokerActivity) error
-	UpsertBrokerActivity(ctx context.Context, record models.BrokerActivity) error
+	UpsertBrokerActivity(ctx context.Context, record models.BrokerActivity) (bool, error)
 }
 
 type brokerActivityRepository struct {
@@ -86,33 +86,23 @@ func (r *brokerActivityRepository) BatchUpsertBrokerActivity(ctx context.Context
 	return nil
 }
 
-func (r *brokerActivityRepository) UpsertBrokerActivity(ctx context.Context, rec models.BrokerActivity) error {
+func (r *brokerActivityRepository) UpsertBrokerActivity(ctx context.Context, rec models.BrokerActivity) (bool, error) {
 	query := `
 		INSERT INTO idxstock.broker_activity (
 			broker_code, stock_code, date, side, lot, value, avg_price, freq, updated_at
 		)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
-		ON CONFLICT (broker_code, stock_code, date, side) DO UPDATE SET
-			lot = EXCLUDED.lot,
-			value = EXCLUDED.value,
-			avg_price = EXCLUDED.avg_price,
-			freq = EXCLUDED.freq,
-			updated_at = now()
-		WHERE
-			idxstock.broker_activity.lot IS DISTINCT FROM EXCLUDED.lot OR
-			idxstock.broker_activity.value IS DISTINCT FROM EXCLUDED.value OR
-			idxstock.broker_activity.avg_price IS DISTINCT FROM EXCLUDED.avg_price OR
-			idxstock.broker_activity.freq IS DISTINCT FROM EXCLUDED.freq
+		ON CONFLICT (broker_code, stock_code, date, side) DO NOTHING
 	`
 
-	_, err := r.pool.Exec(ctx, query,
+	ct, err := r.pool.Exec(ctx, query,
 		rec.BrokerCode, rec.StockCode, rec.Date, rec.Side,
 		rec.Lot, rec.Value, rec.AvgPrice, rec.Freq,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to upsert broker activity (%s, %s, %s, %s): %w",
+		return false, fmt.Errorf("failed to insert broker activity (%s, %s, %s, %s): %w",
 			rec.BrokerCode, rec.StockCode, rec.Date.Format("2006-01-02"), rec.Side, err)
 	}
 
-	return nil
+	return ct.RowsAffected() > 0, nil
 }

--- a/internal/repositories/broker_activity_repository.go
+++ b/internal/repositories/broker_activity_repository.go
@@ -1,0 +1,86 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KAnggara75/IDXStocks/internal/models"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sirupsen/logrus"
+)
+
+type BrokerActivityRepository interface {
+	BatchUpsertBrokerActivity(ctx context.Context, records []models.BrokerActivity) error
+}
+
+type brokerActivityRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewBrokerActivityRepository(pool *pgxpool.Pool) BrokerActivityRepository {
+	return &brokerActivityRepository{
+		pool: pool,
+	}
+}
+
+func (r *brokerActivityRepository) BatchUpsertBrokerActivity(ctx context.Context, records []models.BrokerActivity) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	query := `
+		INSERT INTO idxstock.broker_activity (
+			broker_code, stock_code, date, side, lot, value, avg_price, freq, updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
+		ON CONFLICT (broker_code, stock_code, date, side) DO UPDATE SET
+			lot = EXCLUDED.lot,
+			value = EXCLUDED.value,
+			avg_price = EXCLUDED.avg_price,
+			freq = EXCLUDED.freq,
+			updated_at = now()
+		WHERE
+			idxstock.broker_activity.lot IS DISTINCT FROM EXCLUDED.lot OR
+			idxstock.broker_activity.value IS DISTINCT FROM EXCLUDED.value OR
+			idxstock.broker_activity.avg_price IS DISTINCT FROM EXCLUDED.avg_price OR
+			idxstock.broker_activity.freq IS DISTINCT FROM EXCLUDED.freq
+	`
+
+	batch := &pgx.Batch{}
+	for _, rec := range records {
+		batch.Queue(query,
+			rec.BrokerCode, rec.StockCode, rec.Date, rec.Side,
+			rec.Lot, rec.Value, rec.AvgPrice, rec.Freq,
+		)
+	}
+
+	br := tx.SendBatch(ctx, batch)
+	defer br.Close()
+
+	var affected int64
+	for i := 0; i < len(records); i++ {
+		ct, err := br.Exec()
+		if err != nil {
+			return fmt.Errorf("failed to execute batch upsert for broker activity at index %d: %w", i, err)
+		}
+		affected += ct.RowsAffected()
+	}
+
+	if err := br.Close(); err != nil {
+		return fmt.Errorf("failed to close batch: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	logrus.Infof("Successfully upserted %d broker activity records (affected: %d)", len(records), affected)
+	return nil
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -60,6 +60,7 @@ func Setup(app *fiber.App) {
 	v1.Put("/sectors/sync", sectorHandler.SyncNewSectorsHandler)
 	v1.Put("/industries/sync", industryHandler.IndustrySyncHandler)
 	v1.Get("/broker/sync", brokerHandler.SyncBrokerActivityHandler)
+	v1.Put("/partition/broker-activity", brokerHandler.ManagePartitionsHandler)
 
 	// Asset Routes
 	v1.Get("/assets/logos/companies/:code", assetHandler.GetCompanyLogo)

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -29,6 +29,7 @@ func Setup(app *fiber.App) {
 	industryHandler := handlers.NewIndustryHandler(industryUsecase)
 	sectorHandler := handlers.NewSectorHandler(sectorUsecase)
 	historyHandler := handlers.NewHistoryHandler(historyUsecase)
+	assetHandler := handlers.NewAssetHandler()
 
 	app.Get("/health", func(c fiber.Ctx) error {
 		err := database.Pool.Ping(c.Context())
@@ -54,4 +55,7 @@ func Setup(app *fiber.App) {
 	v1.Get("/stocks/:code/history", historyHandler.GetStockHistoryHandler)
 	v1.Put("/sectors/sync", sectorHandler.SyncNewSectorsHandler)
 	v1.Put("/industries/sync", industryHandler.IndustrySyncHandler)
+
+	// Asset Routes
+	v1.Get("/assets/logos/companies/:code", assetHandler.GetCompanyLogo)
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -15,20 +15,24 @@ func Setup(app *fiber.App) {
 	sectorSearchRepo := repositories.NewSectorSearchRepository(database.Pool)
 	industryRepo := repositories.NewIndustryRepository(database.Pool)
 	historyRepo := repositories.NewHistoryRepository(database.Pool)
+	brokerActRepo := repositories.NewBrokerActivityRepository(database.Pool)
 
 	stockService := services.NewStockService()
 	pasardanaService := services.NewPasardanaService()
 	idxService := services.NewIdxService()
+	brokerService := services.NewBrokerService()
 
 	stockUsecase := usecases.NewStockUsecase(stockRepo, stockService, pasardanaService, idxService)
 	industryUsecase := usecases.NewIndustryUsecase(industryRepo, pasardanaService)
 	sectorUsecase := usecases.NewSectorUsecase(sectorSearchRepo, pasardanaService)
 	historyUsecase := usecases.NewHistoryUsecase(historyRepo, stockRepo, pasardanaService, idxService)
+	brokerUsecase := usecases.NewBrokerUsecase(brokerActRepo, brokerService)
 
 	stockHandler := handlers.NewStockHandler(stockUsecase)
 	industryHandler := handlers.NewIndustryHandler(industryUsecase)
 	sectorHandler := handlers.NewSectorHandler(sectorUsecase)
 	historyHandler := handlers.NewHistoryHandler(historyUsecase)
+	brokerHandler := handlers.NewBrokerHandler(brokerUsecase)
 	assetHandler := handlers.NewAssetHandler()
 
 	app.Get("/health", func(c fiber.Ctx) error {
@@ -55,6 +59,7 @@ func Setup(app *fiber.App) {
 	v1.Get("/stocks/:code/history", historyHandler.GetStockHistoryHandler)
 	v1.Put("/sectors/sync", sectorHandler.SyncNewSectorsHandler)
 	v1.Put("/industries/sync", industryHandler.IndustrySyncHandler)
+	v1.Get("/broker/sync", brokerHandler.SyncBrokerActivityHandler)
 
 	// Asset Routes
 	v1.Get("/assets/logos/companies/:code", assetHandler.GetCompanyLogo)

--- a/internal/services/broker_service.go
+++ b/internal/services/broker_service.go
@@ -1,0 +1,84 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/KAnggara75/IDXStocks/internal/models"
+)
+
+type BrokerService interface {
+	FetchBrokerActivity(ctx context.Context, token string, params models.SyncBrokerActivityParams) (*models.ExodusBrokerActivityResponse, error)
+}
+
+type brokerService struct{}
+
+func NewBrokerService() BrokerService {
+	return &brokerService{}
+}
+
+func (s *brokerService) FetchBrokerActivity(ctx context.Context, token string, params models.SyncBrokerActivityParams) (*models.ExodusBrokerActivityResponse, error) {
+	baseURL := "https://exodus.stockbit.com/order-trade/broker/activity"
+
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse base URL: %w", err)
+	}
+
+	q := u.Query()
+	if params.BrokerCode != "" {
+		q.Set("broker_code", params.BrokerCode)
+	}
+	if params.From != "" {
+		q.Set("from", params.From)
+	}
+	if params.To != "" {
+		q.Set("to", params.To)
+	}
+	if params.TransactionType != "" {
+		q.Set("transaction_type", params.TransactionType)
+	}
+	if params.MarketBoard != "" {
+		q.Set("market_board", params.MarketBoard)
+	}
+	if params.InvestorType != "" {
+		q.Set("investor_type", params.InvestorType)
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Forward Bearer token
+	if token != "" {
+		req.Header.Set("Authorization", token)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36")
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch from Exodus: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Exodus API returned status: %d", resp.StatusCode)
+	}
+
+	var exodusResp models.ExodusBrokerActivityResponse
+	if err := json.NewDecoder(resp.Body).Decode(&exodusResp); err != nil {
+		return nil, fmt.Errorf("failed to decode Exodus response: %w", err)
+	}
+
+	return &exodusResp, nil
+}

--- a/internal/usecases/broker_usecase.go
+++ b/internal/usecases/broker_usecase.go
@@ -6,6 +6,8 @@ import (
 	"math"
 	"time"
 
+	"strings"
+
 	"github.com/KAnggara75/IDXStocks/internal/models"
 	"github.com/KAnggara75/IDXStocks/internal/repositories"
 	"github.com/KAnggara75/IDXStocks/internal/services"
@@ -53,7 +55,7 @@ func (u *brokerUsecase) SyncBrokerActivity(ctx context.Context, token string, pa
 
 	// Map Buy items
 	for _, item := range exodusResp.Data.BrokerActivityTransaction.BrokersBuy {
-		if len(item.StockCode) > 4 {
+		if len(item.StockCode) > 4 || strings.HasPrefix(item.StockCode, "X") {
 			continue
 		}
 		records = append(records, mapItem(item, "buy"))
@@ -61,7 +63,7 @@ func (u *brokerUsecase) SyncBrokerActivity(ctx context.Context, token string, pa
 
 	// Map Sell items
 	for _, item := range exodusResp.Data.BrokerActivityTransaction.BrokersSell {
-		if len(item.StockCode) > 4 {
+		if len(item.StockCode) > 4 || strings.HasPrefix(item.StockCode, "X") {
 			continue
 		}
 		records = append(records, mapItem(item, "sell"))

--- a/internal/usecases/broker_usecase.go
+++ b/internal/usecases/broker_usecase.go
@@ -53,11 +53,17 @@ func (u *brokerUsecase) SyncBrokerActivity(ctx context.Context, token string, pa
 
 	// Map Buy items
 	for _, item := range exodusResp.Data.BrokerActivityTransaction.BrokersBuy {
+		if len(item.StockCode) > 4 {
+			continue
+		}
 		records = append(records, mapItem(item, "buy"))
 	}
 
 	// Map Sell items
 	for _, item := range exodusResp.Data.BrokerActivityTransaction.BrokersSell {
+		if len(item.StockCode) > 4 {
+			continue
+		}
 		records = append(records, mapItem(item, "sell"))
 	}
 

--- a/internal/usecases/broker_usecase.go
+++ b/internal/usecases/broker_usecase.go
@@ -3,6 +3,7 @@ package usecases
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/KAnggara75/IDXStocks/internal/models"
@@ -43,8 +44,8 @@ func (u *brokerUsecase) SyncBrokerActivity(ctx context.Context, token string, pa
 			StockCode:  item.StockCode,
 			Date:       t,
 			Side:       side,
-			Lot:        item.Lot,
-			Value:      item.Value,
+			Lot:        int64(math.Round(item.Lot)),
+			Value:      int64(math.Round(item.Value)),
 			AvgPrice:   item.AvgPrice,
 			Freq:       item.Freq,
 		}

--- a/internal/usecases/broker_usecase.go
+++ b/internal/usecases/broker_usecase.go
@@ -1,0 +1,71 @@
+package usecases
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/KAnggara75/IDXStocks/internal/models"
+	"github.com/KAnggara75/IDXStocks/internal/repositories"
+	"github.com/KAnggara75/IDXStocks/internal/services"
+	"github.com/sirupsen/logrus"
+)
+
+type BrokerUsecase interface {
+	SyncBrokerActivity(ctx context.Context, token string, params models.SyncBrokerActivityParams) ([]models.BrokerActivity, error)
+}
+
+type brokerUsecase struct {
+	repo          repositories.BrokerActivityRepository
+	brokerService services.BrokerService
+}
+
+func NewBrokerUsecase(repo repositories.BrokerActivityRepository, brokerService services.BrokerService) BrokerUsecase {
+	return &brokerUsecase{
+		repo:          repo,
+		brokerService: brokerService,
+	}
+}
+
+func (u *brokerUsecase) SyncBrokerActivity(ctx context.Context, token string, params models.SyncBrokerActivityParams) ([]models.BrokerActivity, error) {
+	exodusResp, err := u.brokerService.FetchBrokerActivity(ctx, token, params)
+	if err != nil {
+		return nil, err
+	}
+
+	var records []models.BrokerActivity
+
+	// Helper function for mapping
+	mapItem := func(item models.ExodusBrokerActivityItem, side string) models.BrokerActivity {
+		t, _ := time.Parse("2006-01-02", item.Date)
+		return models.BrokerActivity{
+			BrokerCode: item.BrokerCode,
+			StockCode:  item.StockCode,
+			Date:       t,
+			Side:       side,
+			Lot:        item.Lot,
+			Value:      item.Value,
+			AvgPrice:   item.AvgPrice,
+			Freq:       item.Freq,
+		}
+	}
+
+	// Map Buy items
+	for _, item := range exodusResp.Data.BrokerActivityTransaction.BrokersBuy {
+		records = append(records, mapItem(item, "buy"))
+	}
+
+	// Map Sell items
+	for _, item := range exodusResp.Data.BrokerActivityTransaction.BrokersSell {
+		records = append(records, mapItem(item, "sell"))
+	}
+
+	if len(records) > 0 {
+		if err := u.repo.BatchUpsertBrokerActivity(ctx, records); err != nil {
+			logrus.Errorf("Failed to upsert broker activity: %v", err)
+			return nil, fmt.Errorf("failed to save broker activity to database: %w", err)
+		}
+	}
+
+	return records, nil
+}

--- a/internal/usecases/broker_usecase.go
+++ b/internal/usecases/broker_usecase.go
@@ -72,7 +72,7 @@ func (u *brokerUsecase) SyncBrokerActivity(ctx context.Context, token string, pa
 	var errs []error
 	var insertedRecords []models.BrokerActivity
 	for _, rec := range records {
-		inserted, err := u.repo.UpsertBrokerActivity(ctx, rec)
+		inserted, err := u.repo.InsertBrokerActivity(ctx, rec)
 		if err != nil {
 			logrus.Errorf("Error inserting record: %v", err)
 			errs = append(errs, err)

--- a/internal/usecases/broker_usecase.go
+++ b/internal/usecases/broker_usecase.go
@@ -2,7 +2,7 @@ package usecases
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"math"
 	"time"
 
@@ -67,11 +67,16 @@ func (u *brokerUsecase) SyncBrokerActivity(ctx context.Context, token string, pa
 		records = append(records, mapItem(item, "sell"))
 	}
 
-	if len(records) > 0 {
-		if err := u.repo.BatchUpsertBrokerActivity(ctx, records); err != nil {
-			logrus.Errorf("Failed to upsert broker activity: %v", err)
-			return nil, fmt.Errorf("failed to save broker activity to database: %w", err)
+	var errs []error
+	for _, rec := range records {
+		if err := u.repo.UpsertBrokerActivity(ctx, rec); err != nil {
+			logrus.Errorf("Error upserting record: %v", err)
+			errs = append(errs, err)
 		}
+	}
+
+	if len(errs) > 0 {
+		return records, errors.Join(errs...)
 	}
 
 	return records, nil

--- a/internal/usecases/broker_usecase.go
+++ b/internal/usecases/broker_usecase.go
@@ -3,6 +3,7 @@ package usecases
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 
 type BrokerUsecase interface {
 	SyncBrokerActivity(ctx context.Context, token string, params models.SyncBrokerActivityParams) ([]models.BrokerActivity, error)
+	ManagePartitions(ctx context.Context) (*models.PartitionManagementResponse, error)
 }
 
 type brokerUsecase struct {
@@ -88,4 +90,60 @@ func (u *brokerUsecase) SyncBrokerActivity(ctx context.Context, token string, pa
 	}
 
 	return insertedRecords, nil
+}
+
+func (u *brokerUsecase) ManagePartitions(ctx context.Context) (*models.PartitionManagementResponse, error) {
+	today := time.Now()
+
+	// Helper to find next Monday
+	// today.Weekday(): 0 (Sun), 1 (Mon) ... 6 (Sat)
+	// If today is Monday (1), we want next Monday (7 days away) or stay (0 days)?
+	// The requirement: "hit on 17 Apr (Fri) -> 20 Apr (Mon)".
+	// 20 Apr is the next Monday.
+
+	resp := &models.PartitionManagementResponse{
+		Details: make([]models.PartitionDetail, 0),
+	}
+
+	for i := 0; i < 2; i++ {
+		// Calculate target Monday
+		// Days to next Monday: 1 - current weekday + (7 if weekday >= 1 else 0)
+		daysToMonday := (8 - int(today.Weekday())) % 7
+		if daysToMonday == 0 {
+			daysToMonday = 7
+		}
+
+		// Start of week i (0-based)
+		startOfWeek := today.AddDate(0, 0, daysToMonday+(i*7))
+		endOfWeek := startOfWeek.AddDate(0, 0, 7) // To Monday next week (exclusive bound)
+
+		year, week := startOfWeek.ISOWeek()
+		tableName := fmt.Sprintf("broker_activity_p_%d_w%02d", year, week)
+		rangeStr := fmt.Sprintf("%s to %s", startOfWeek.Format("2006-01-02"), endOfWeek.AddDate(0, 0, -1).Format("2006-01-02"))
+
+		exists, err := u.repo.CheckPartitionExists(ctx, tableName)
+		if err != nil {
+			return nil, err
+		}
+
+		detail := models.PartitionDetail{
+			Name:  tableName,
+			Range: rangeStr,
+		}
+
+		if exists {
+			detail.Status = "exists"
+		} else {
+			err := u.repo.CreatePartition(ctx, tableName, startOfWeek.Format("2006-01-02"), endOfWeek.Format("2006-01-02"))
+			if err != nil {
+				return nil, err
+			}
+			detail.Status = "created"
+			resp.PartitionsCreated++
+		}
+
+		resp.Details = append(resp.Details, detail)
+	}
+
+	return resp, nil
 }

--- a/internal/usecases/broker_usecase.go
+++ b/internal/usecases/broker_usecase.go
@@ -33,7 +33,7 @@ func NewBrokerUsecase(repo repositories.BrokerActivityRepository, brokerService 
 func (u *brokerUsecase) SyncBrokerActivity(ctx context.Context, token string, params models.SyncBrokerActivityParams) ([]models.BrokerActivity, error) {
 	exodusResp, err := u.brokerService.FetchBrokerActivity(ctx, token, params)
 	if err != nil {
-		return nil, err
+		return make([]models.BrokerActivity, 0), err
 	}
 
 	var records []models.BrokerActivity
@@ -70,7 +70,7 @@ func (u *brokerUsecase) SyncBrokerActivity(ctx context.Context, token string, pa
 	}
 
 	var errs []error
-	var insertedRecords []models.BrokerActivity
+	insertedRecords := make([]models.BrokerActivity, 0)
 	for _, rec := range records {
 		inserted, err := u.repo.InsertBrokerActivity(ctx, rec)
 		if err != nil {

--- a/internal/usecases/broker_usecase.go
+++ b/internal/usecases/broker_usecase.go
@@ -70,16 +70,22 @@ func (u *brokerUsecase) SyncBrokerActivity(ctx context.Context, token string, pa
 	}
 
 	var errs []error
+	var insertedRecords []models.BrokerActivity
 	for _, rec := range records {
-		if err := u.repo.UpsertBrokerActivity(ctx, rec); err != nil {
-			logrus.Errorf("Error upserting record: %v", err)
+		inserted, err := u.repo.UpsertBrokerActivity(ctx, rec)
+		if err != nil {
+			logrus.Errorf("Error inserting record: %v", err)
 			errs = append(errs, err)
+			continue
+		}
+		if inserted {
+			insertedRecords = append(insertedRecords, rec)
 		}
 	}
 
 	if len(errs) > 0 {
-		return records, errors.Join(errs...)
+		return insertedRecords, errors.Join(errs...)
 	}
 
-	return records, nil
+	return insertedRecords, nil
 }

--- a/migrations/006_create_broker_activity_table.sql
+++ b/migrations/006_create_broker_activity_table.sql
@@ -1,7 +1,4 @@
--- Drop existing if exists to recreate with partitioning
-DROP TABLE IF EXISTS idxstock.broker_activity;
-
-CREATE TABLE idxstock.broker_activity (
+CREATE TABLE IF NOT EXISTS idxstock.broker_activity (
     broker_code VARCHAR NOT NULL REFERENCES idxstock.brokers(code),
     stock_code VARCHAR NOT NULL REFERENCES idxstock.stocks(code),
     date DATE NOT NULL,

--- a/migrations/006_create_broker_activity_table.sql
+++ b/migrations/006_create_broker_activity_table.sql
@@ -9,9 +9,9 @@ CREATE TABLE IF NOT EXISTS idxstock.broker_activity (
     freq BIGINT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (broker_code, stock_code, date, side)
+    PRIMARY KEY (broker_code, date, stock_code, side)
 );
 
 -- Indeks kombinasi untuk mempercepat pencarian (sering dipakai):
 CREATE INDEX IF NOT EXISTS idx_broker_act_bd ON idxstock.broker_activity (broker_code, date);
-CREATE INDEX IF NOT EXISTS idx_broker_act_bsd ON idxstock.broker_activity (broker_code, stock_code, date);
+CREATE INDEX IF NOT EXISTS idx_broker_act_bsd ON idxstock.broker_activity (broker_code, date, stock_code);

--- a/migrations/006_create_broker_activity_table.sql
+++ b/migrations/006_create_broker_activity_table.sql
@@ -1,4 +1,7 @@
-CREATE TABLE IF NOT EXISTS idxstock.broker_activity (
+-- Drop existing if exists to recreate with partitioning
+DROP TABLE IF EXISTS idxstock.broker_activity;
+
+CREATE TABLE idxstock.broker_activity (
     broker_code VARCHAR NOT NULL REFERENCES idxstock.brokers(code),
     stock_code VARCHAR NOT NULL REFERENCES idxstock.stocks(code),
     date DATE NOT NULL,
@@ -10,8 +13,17 @@ CREATE TABLE IF NOT EXISTS idxstock.broker_activity (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (broker_code, date, stock_code, side)
-);
+) PARTITION BY RANGE (date);
 
--- Indeks kombinasi untuk mempercepat pencarian (sering dipakai):
+-- Indeks kombinasi untuk mempercepat pencarian:
 CREATE INDEX IF NOT EXISTS idx_broker_act_bd ON idxstock.broker_activity (broker_code, date);
 CREATE INDEX IF NOT EXISTS idx_broker_act_bsd ON idxstock.broker_activity (broker_code, date, stock_code);
+
+-- Default partition untuk menampung data yang belum memiliki partisi spesifik
+CREATE TABLE IF NOT EXISTS idxstock.broker_activity_default
+PARTITION OF idxstock.broker_activity DEFAULT;
+
+-- Contoh pembuatan partisi bulanan manual (Opsional: Bisa ditambahkan sesuai kebutuhan range data)
+-- CREATE TABLE IF NOT EXISTS idxstock.broker_activity_y2026m04
+-- PARTITION OF idxstock.broker_activity
+-- FOR VALUES FROM ('2026-04-01') TO ('2026-05-01');

--- a/migrations/006_create_broker_activity_table.sql
+++ b/migrations/006_create_broker_activity_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS idxstock.broker_activity (
+    broker_code VARCHAR NOT NULL REFERENCES idxstock.brokers(code),
+    stock_code VARCHAR NOT NULL REFERENCES idxstock.stocks(code),
+    date DATE NOT NULL,
+    side VARCHAR(10) NOT NULL CHECK (side IN ('buy', 'sell')),
+    lot BIGINT,
+    value BIGINT,
+    avg_price DECIMAL,
+    freq BIGINT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (broker_code, stock_code, date, side)
+);
+
+-- Indeks kombinasi untuk mempercepat pencarian (sering dipakai):
+CREATE INDEX IF NOT EXISTS idx_broker_act_bd ON idxstock.broker_activity (broker_code, date);
+CREATE INDEX IF NOT EXISTS idx_broker_act_bsd ON idxstock.broker_activity (broker_code, stock_code, date);


### PR DESCRIPTION
## Description
This PR implements the automated management of PostgreSQL partitions for the `idxstock.broker_activity` table as specified in Issue #38.

### Changes:
- **Repository**: Added `CheckPartitionExists` and `CreatePartition` to `BrokerActivityRepository`.
- **Usecase**: Implemented `ManagePartitions` logic to calculate the next two ISO weeks (Monday to Sunday) and ensure their partitions exist.
- **Handler**: Added `ManagePartitionsHandler` to handle the `PUT /api/v1/partition/broker-activity` request.
- **Routes**: Registered the new maintenance endpoint.

### Behavior:
- When called, it calculates the date ranges for the upcoming Mon-Sun weeks.
- It checks if a partition for that week (e.g., `p_2026_w17`) already exists.
- If not, it creates the partition starting from Monday up to the next Monday (exclusive).
- Returns **201 Created** if any partition was added, or **200 OK** if all already exist.

### How to verify:
1. Call `PUT http://localhost:3000/api/v1/partition/broker-activity`.
2. Verify the response JSON reveals the created/existing partitions.
3. Check the database to confirm the new tables exist under the `idxstock` schema.